### PR TITLE
NamedTemporaryFile works different on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@
 /*.egg-info
 /build
 /dist
-.idea/
-*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /*.egg-info
 /build
 /dist
+.idea/
+*.pyc

--- a/pyannotate_tools/annotations/__main__.py
+++ b/pyannotate_tools/annotations/__main__.py
@@ -42,7 +42,7 @@ def main():
 
     # Run pass 2 with output written to a temporary file.
     infile = args.type_info
-    generate_annotations_json(infile, tf.name, target_stream=tf.file)
+    generate_annotations_json(infile, tf.name, target_stream=tf)
 
     # Run pass 3 reading from a temporary file.
     FixAnnotateJson.stub_json_file = tf.name

--- a/pyannotate_tools/annotations/__main__.py
+++ b/pyannotate_tools/annotations/__main__.py
@@ -42,7 +42,7 @@ def main():
 
     # Run pass 2 with output written to a temporary file.
     infile = args.type_info
-    generate_annotations_json(infile, tf.name)
+    generate_annotations_json(infile, tf.name, target_stream=tf.file)
 
     # Run pass 3 reading from a temporary file.
     FixAnnotateJson.stub_json_file = tf.name

--- a/pyannotate_tools/annotations/main.py
+++ b/pyannotate_tools/annotations/main.py
@@ -1,8 +1,9 @@
 """Main entry point to mypy annotation inference utility."""
 
 import json
+from io import IOBase
 
-from typing import List
+from typing import List, Optional
 from mypy_extensions import TypedDict
 
 from pyannotate_tools.annotations.types import ARG_STAR, ARG_STARSTAR
@@ -22,8 +23,8 @@ FunctionData = TypedDict('FunctionData', {'path': str,
                                           'samples': int})
 
 
-def generate_annotations_json(source_path, target_path):
-    # type: (str, str) -> None
+def generate_annotations_json(source_path, target_path, source_stream=None, target_stream=None):
+    # type: (str, str, Optional[IOBase], Optional[IOBase]) -> None
     """Produce annotation data JSON file from a JSON file with runtime-collected types.
 
     Data formats:
@@ -31,7 +32,7 @@ def generate_annotations_json(source_path, target_path):
     * The source JSON is a list of pyannotate_tools.annotations.parse.RawEntry items.
     * The output JSON is a list of FunctionData items.
     """
-    items = parse_json(source_path)
+    items = parse_json(source_path, source_stream)
     results = []
     for item in items:
         arg_types, return_type = infer_annotation(item.type_comments)
@@ -55,5 +56,8 @@ def generate_annotations_json(source_path, target_path):
             'samples': item.samples
         }  # type: FunctionData
         results.append(data)
-    with open(target_path, 'w') as f:
-        json.dump(results, f, sort_keys=True, indent=4)
+    if isinstance(target_stream, IOBase):
+        json.dump(results, target_stream, sort_keys=True, indent=4)
+    else:
+        with open(target_path, 'w') as f:
+            json.dump(results, f, sort_keys=True, indent=4)

--- a/pyannotate_tools/annotations/main.py
+++ b/pyannotate_tools/annotations/main.py
@@ -1,9 +1,8 @@
 """Main entry point to mypy annotation inference utility."""
 
 import json
-from io import IOBase
 
-from typing import List, Optional
+from typing import List, Optional, IO
 from mypy_extensions import TypedDict
 
 from pyannotate_tools.annotations.types import ARG_STAR, ARG_STARSTAR
@@ -24,7 +23,7 @@ FunctionData = TypedDict('FunctionData', {'path': str,
 
 
 def generate_annotations_json(source_path, target_path, source_stream=None, target_stream=None):
-    # type: (str, str, Optional[IOBase], Optional[IOBase]) -> None
+    # type: (str, str, Optional[IO[str]], Optional[IO[str]]) -> None
     """Produce annotation data JSON file from a JSON file with runtime-collected types.
 
     Data formats:
@@ -56,7 +55,7 @@ def generate_annotations_json(source_path, target_path, source_stream=None, targ
             'samples': item.samples
         }  # type: FunctionData
         results.append(data)
-    if isinstance(target_stream, IOBase):
+    if target_stream:
         json.dump(results, target_stream, sort_keys=True, indent=4)
     else:
         with open(target_path, 'w') as f:

--- a/pyannotate_tools/annotations/parse.py
+++ b/pyannotate_tools/annotations/parse.py
@@ -8,9 +8,8 @@ The collect_types tool is in pyannotate_runtime/collect_types.py.
 import json
 import re
 import sys
-from io import IOBase
 
-from typing import Any, List, Mapping, Set, Text, Tuple, Optional
+from typing import Any, List, Mapping, Set, Text, Tuple, Optional, IO
 
 from mypy_extensions import NoReturn, TypedDict
 
@@ -87,16 +86,16 @@ class ParseError(Exception):
 
 
 def parse_json(path, stream=None):
-    # type: (str, Optional[IOBase]) -> List[FunctionInfo]
+    # type: (str, Optional[IO[str]]) -> List[FunctionInfo]
     """Deserialize a JSON file containing runtime collected types.
 
     The input JSON is expected to to have a list of RawEntry items.
     """
-    if isinstance(stream, IOBase):
-        data = json.load(stream)
+    if stream:
+        data = json.load(stream)  # type: List[RawEntry]
     else:
         with open(path) as f:
-            data = json.load(f)  # type: List[RawEntry]
+            data = json.load(f)
     result = []
 
     def assert_type(value, typ):

--- a/pyannotate_tools/annotations/parse.py
+++ b/pyannotate_tools/annotations/parse.py
@@ -8,8 +8,9 @@ The collect_types tool is in pyannotate_runtime/collect_types.py.
 import json
 import re
 import sys
+from io import IOBase
 
-from typing import Any, List, Mapping, Set, Text, Tuple
+from typing import Any, List, Mapping, Set, Text, Tuple, Optional
 
 from mypy_extensions import NoReturn, TypedDict
 
@@ -85,14 +86,17 @@ class ParseError(Exception):
         self.comment = comment
 
 
-def parse_json(path):
-    # type: (str) -> List[FunctionInfo]
+def parse_json(path, stream=None):
+    # type: (str, Optional[IOBase]) -> List[FunctionInfo]
     """Deserialize a JSON file containing runtime collected types.
 
     The input JSON is expected to to have a list of RawEntry items.
     """
-    with open(path) as f:
-        data = json.load(f)  # type: List[RawEntry]
+    if isinstance(stream, IOBase):
+        data = json.load(stream)
+    else:
+        with open(path) as f:
+            data = json.load(f)  # type: List[RawEntry]
     result = []
 
     def assert_type(value, typ):

--- a/pyannotate_tools/annotations/tests/parse_test.py
+++ b/pyannotate_tools/annotations/tests/parse_test.py
@@ -43,9 +43,9 @@ class TestParseJson(unittest.TestCase):
         with tempfile.NamedTemporaryFile(mode='w+') as f:
             f.write(data)
             f.flush()
-            f.file.seek(0)
+            f.seek(0)
 
-            result = parse_json(f.name, f.file)
+            result = parse_json(f.name, f)
         assert len(result) == 1
         item = result[0]
         assert item.path == 'pkg/thing.py'

--- a/pyannotate_tools/annotations/tests/parse_test.py
+++ b/pyannotate_tools/annotations/tests/parse_test.py
@@ -40,11 +40,12 @@ class TestParseJson(unittest.TestCase):
             }
         ]
         """
-        with tempfile.NamedTemporaryFile(mode='w') as f:
+        with tempfile.NamedTemporaryFile(mode='w+') as f:
             f.write(data)
             f.flush()
+            f.file.seek(0)
 
-            result = parse_json(f.name)
+            result = parse_json(f.name, f.file)
         assert len(result) == 1
         item = result[0]
         assert item.path == 'pkg/thing.py'


### PR DESCRIPTION
Add optional stream parameters to generate_annotation_json and parse_json.

Hopefully fixes #25 but unable to run all tests due to lib2to3 quirks on Windows and Ubuntu