### PR TITLE
Fix annotationg keyword-only arguments.

### DIFF
--- a/pyannotate_tools/fixes/fix_annotate_json.py
+++ b/pyannotate_tools/fixes/fix_annotate_json.py
@@ -116,12 +116,15 @@ def count_args(node, results):
     # Interpret children according to the following grammar:
     # (('*'|'**')? NAME ['=' expr] ','?)*
     skip = False
+    previous_token_is_star = False
     for child in children:
         if skip:
             skip = False
         elif isinstance(child, Leaf):
+            # A single '*' indicates the rest of the arguments are keyword only
+            # and shouldn't be counted as a `*`.
             if child.type == token.STAR:
-                star = True
+                previous_token_is_star = True
             elif child.type == token.DOUBLESTAR:
                 starstar = True
             elif child.type == token.NAME:
@@ -129,8 +132,12 @@ def count_args(node, results):
                     if child.value in ('self', 'cls'):
                         selfish = True
                 count += 1
+                if previous_token_is_star:
+                    star = True
             elif child.type == token.EQUAL:
                 skip = True
+            if child.type != token.STAR:
+                previous_token_is_star = False
     return count, selfish, star, starstar
 
 class FixAnnotateJson(FixAnnotate):

--- a/pyannotate_tools/fixes/tests/test_annotate_json.py
+++ b/pyannotate_tools/fixes/tests/test_annotate_json.py
@@ -56,6 +56,31 @@ class TestFixAnnotateJson(FixerTestCase):
             """
         self.check(a, b)
 
+    def test_keyword_only_argument(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 3,
+              "signature": {
+                  "arg_types": ["Foo", "Bar"],
+                  "return_type": "Any"},
+              }])
+        a = """\
+            class Foo: pass
+            class Bar: pass
+            def nop(foo, *, bar):
+                return 42
+            """
+        b = """\
+            from typing import Any
+            class Foo: pass
+            class Bar: pass
+            def nop(foo, *, bar):
+                # type: (Foo, Bar) -> Any
+                return 42
+            """
+        self.check(a, b)
+
     def test_add_typing_import(self):
         self.setTestData(
             [{"func_name": "nop",


### PR DESCRIPTION
This fixes https://github.com/dropbox/pyannotate/issues/31