### PR TITLE
Ignore mocks when infering types.

### DIFF
--- a/pyannotate_tools/annotations/tests/infer_test.py
+++ b/pyannotate_tools/annotations/tests/infer_test.py
@@ -101,6 +101,12 @@ class TestInfer(unittest.TestCase):
         actual = infer_annotation(comments)
         assert actual == expected
 
+    def test_infer_ignore_mock(self):
+        # type: () -> None
+        self.assert_infer(['(mock.mock.Mock) -> None',
+                           '(str) -> None'],
+                           ([(ClassType('str'), ARG_POS)],
+                            ClassType('None')))
 
 CT = ClassType
 


### PR DESCRIPTION
We're experimenting with pyannotate using our tests and one of the first things we hit was every type
being a union with `Mock`.