### PR TITLE
Remove redundant Dict/List/Set unions.

### DIFF
--- a/pyannotate_tools/annotations/infer.py
+++ b/pyannotate_tools/annotations/infer.py
@@ -55,7 +55,7 @@ def infer_annotation(type_comments):
         combined = combine_types(types)
         if kind != ARG_POS and (len(str(combined)) > 120 or isinstance(combined, UnionType)):
             # Avoid some noise.
-            combined = AnyType(is_fallback=True)
+            combined = AnyType()
         combined_args.append(Argument(combined, kind))
     combined_return = combine_types(returns)
     return combined_args, combined_return
@@ -94,11 +94,10 @@ def simplify_types(types):
     items = filter_ignored_items(flattened)
     items = remove_redundant_items(items)
     items = [simplify_recursive(item) for item in items]
-    items = remove_redundant_items(items)
     items = merge_items(items)
     items = dedupe_types(items)
     if len(items) > 3:
-        return [AnyType(is_fallback=True)]
+        return [AnyType()]
     else:
         return items
 
@@ -115,7 +114,7 @@ def simplify_recursive(typ):
                 and isinstance(args[0], ClassType) and args[0].name in ('str', 'Text')
                 and isinstance(args[1], UnionType) and not is_optional(args[1])):
             # Looks like a potential case for TypedDict, which we don't properly support yet.
-            return ClassType('Dict', [args[0], AnyType(is_fallback=True)])
+            return ClassType('Dict', [args[0], AnyType()])
         return simplified
     elif isinstance(typ, TupleType):
         return TupleType([simplify_recursive(item) for item in typ.items])
@@ -176,9 +175,7 @@ def is_redundant_union_item(first, other):
             if not first.args and other.args:
                 return True
             elif len(first.args) == len(other.args) and first.args:
-                result = all((first_arg == other_arg or
-                              isinstance(other_arg, AnyType) and
-                              other_arg.is_fallback)
+                result = all(first_arg == other_arg or other_arg == AnyType()
                              for first_arg, other_arg
                              in zip(first.args, other.args))
                 return result

--- a/pyannotate_tools/annotations/infer.py
+++ b/pyannotate_tools/annotations/infer.py
@@ -170,9 +170,16 @@ def is_redundant_union_item(first, other):
             return True
         elif first.name == 'int' and other.name == 'float':
             return True
-        elif (first.name in ('List', 'Dict', 'Set') and not first.args and other.args
-              and other.name == first.name):
-            return True
+        elif (first.name in ('List', 'Dict', 'Set') and
+                  other.name == first.name):
+            if not first.args and other.args:
+                return True
+            elif len(first.args) == len(other.args) and first.args:
+                result = all(first_arg == other_arg or other_arg == AnyType()
+                             for first_arg, other_arg
+                             in zip(first.args, other.args))
+                return result
+
     return False
 
 

--- a/pyannotate_tools/annotations/tests/infer_test.py
+++ b/pyannotate_tools/annotations/tests/infer_test.py
@@ -66,7 +66,7 @@ class TestInfer(unittest.TestCase):
 
     def test_remove_redundant_dict_item(self):
         # type: () -> None
-        self.assert_infer(['(Dict[str, Union[str, int, List[int], Dict]]) -> None',
+        self.assert_infer(['(Dict[str, Any]) -> None',
                            '(Dict[str, str]) -> None'],
                            ([(ClassType('Dict', [ClassType('str'), AnyType()]), ARG_POS)],
                             ClassType('None')))

--- a/pyannotate_tools/annotations/tests/infer_test.py
+++ b/pyannotate_tools/annotations/tests/infer_test.py
@@ -66,7 +66,7 @@ class TestInfer(unittest.TestCase):
 
     def test_remove_redundant_dict_item(self):
         # type: () -> None
-        self.assert_infer(['(Dict[str, Any]) -> None',
+        self.assert_infer(['(Dict[str, Union[str, int, List[int], Dict]]) -> None',
                            '(Dict[str, str]) -> None'],
                            ([(ClassType('Dict', [ClassType('str'), AnyType()]), ARG_POS)],
                             ClassType('None')))

--- a/pyannotate_tools/annotations/tests/infer_test.py
+++ b/pyannotate_tools/annotations/tests/infer_test.py
@@ -64,6 +64,13 @@ class TestInfer(unittest.TestCase):
                            ([(ClassType('Text'), ARG_POS)],
                             ClassType('None')))
 
+    def test_remove_redundant_dict_item(self):
+        # type: () -> None
+        self.assert_infer(['(Dict[str, Any]) -> None',
+                           '(Dict[str, str]) -> None'],
+                           ([(ClassType('Dict', [ClassType('str'), AnyType()]), ARG_POS)],
+                            ClassType('None')))
+
     def test_simplify_list_item_types(self):
         # type: () -> None
         self.assert_infer(['(List[Union[bool, int]]) -> None'],

--- a/pyannotate_tools/annotations/types.py
+++ b/pyannotate_tools/annotations/types.py
@@ -38,6 +38,9 @@ class ClassType(AbstractType):
 
 class AnyType(AbstractType):
     """The type Any"""
+    def __init__(self, is_fallback=False):
+        # typeL (bool) -> None
+        self.is_fallback = is_fallback
 
     def __repr__(self):
         # type: () -> str

--- a/pyannotate_tools/annotations/types.py
+++ b/pyannotate_tools/annotations/types.py
@@ -39,7 +39,7 @@ class ClassType(AbstractType):
 class AnyType(AbstractType):
     """The type Any"""
     def __init__(self, is_fallback=False):
-        # typeL (bool) -> None
+        # type: (bool) -> None
         self.is_fallback = is_fallback
 
     def __repr__(self):

--- a/pyannotate_tools/annotations/types.py
+++ b/pyannotate_tools/annotations/types.py
@@ -39,7 +39,7 @@ class ClassType(AbstractType):
 class AnyType(AbstractType):
     """The type Any"""
     def __init__(self, is_fallback=False):
-        # type: (bool) -> None
+        # typeL (bool) -> None
         self.is_fallback = is_fallback
 
     def __repr__(self):

--- a/pyannotate_tools/annotations/types.py
+++ b/pyannotate_tools/annotations/types.py
@@ -38,9 +38,6 @@ class ClassType(AbstractType):
 
 class AnyType(AbstractType):
     """The type Any"""
-    def __init__(self, is_fallback=False):
-        # typeL (bool) -> None
-        self.is_fallback = is_fallback
 
     def __repr__(self):
         # type: () -> str


### PR DESCRIPTION
We currently generate some redundant types such as:
`Union[Dict[str, str], Dict[str, Any]]`.