### PR TITLE
Fix a pyannotate crash on code using `pytz`

### DIFF
--- a/pyannotate_tools/annotations/parse.py
+++ b/pyannotate_tools/annotations/parse.py
@@ -202,7 +202,9 @@ def tokenize(s):
             if fullname.startswith('pytz.tzfile.'):
                 fullname = 'datetime.tzinfo'
             if '-' in fullname or '/' in fullname:
-                # Not a valid Python name
+                # Not a valid Python name; there are many places that
+                # generate these, so we just substitute Any rather
+                # than crashing.
                 fullname = 'Any'
             tokens.append(DottedName(fullname))
             s = s[len(m.group(0)):]

--- a/pyannotate_tools/annotations/parse.py
+++ b/pyannotate_tools/annotations/parse.py
@@ -195,10 +195,14 @@ def tokenize(s):
             fullname = fullname.replace(' ', '')
             if fullname in TYPE_FIXUPS:
                 fullname = TYPE_FIXUPS[fullname]
+            # pytz creates classes with the name of the timezone being used:
+            # https://github.com/stub42/pytz/blob/f55399cddbef67c56db1b83e0939ecc1e276cf42/src/pytz/tzfile.py#L120-L123
+            # This causes pyannotates to crash as it's invalid to have a class
+            # name with a `/` in it (e.g. "pytz.tzfile.America/Los_Angeles")
+            if fullname.startswith('pytz.tzfile.'):
+                fullname = 'datetime.tzinfo'
             if '-' in fullname or '/' in fullname:
-                # Not a valid Python name; there are many places that
-                # generate these, so we just substitute Any rather
-                # than crashing.
+                # Not a valid Python name
                 fullname = 'Any'
             tokens.append(DottedName(fullname))
             s = s[len(m.group(0)):]

--- a/pyannotate_tools/annotations/tests/parse_test.py
+++ b/pyannotate_tools/annotations/tests/parse_test.py
@@ -72,7 +72,8 @@ class TestTokenize(unittest.TestCase):
         self.assert_tokenize('dictionary-valueiterator',
                              'DottedName(Iterator) End()')
         self.assert_tokenize('foo-bar', 'DottedName(Any) End()')
-        self.assert_tokenize('pytz.tzfile.Europe/Amsterdam', 'DottedName(Any) End()')
+        self.assert_tokenize('pytz.tzfile.Europe/Amsterdam',
+                             'DottedName(datetime.tzinfo) End()')
 
     def assert_tokenize(self, s, expected):
         # type: (str, str) -> None


### PR DESCRIPTION
pytz creates classes with the name of the timezone being used:
https://github.com/stub42/pytz/blob/f55399cddbef67c56db1b83e0939ecc1e276cf42/src/pytz/tzfile.py#L120-L123
This causes pyannotates to crash as it's invalid to have a class
name with a `/` in it (e.g. "pytz.tzfile.America/Los_Angeles")