### PR TITLE
Remove redundant items last when simplifying types.

### DIFF
--- a/pyannotate_tools/annotations/infer.py
+++ b/pyannotate_tools/annotations/infer.py
@@ -92,10 +92,12 @@ def simplify_types(types):
     """Given some types, give simplified types representing the union of types."""
     flattened = flatten_types(types)
     items = filter_ignored_items(flattened)
-    items = remove_redundant_items(items)
     items = [simplify_recursive(item) for item in items]
     items = merge_items(items)
     items = dedupe_types(items)
+    # We have to remove reundant items after everything has been simplified and
+    # merged as this simplification may be what makes items redundant.
+    items = remove_redundant_items(items)
     if len(items) > 3:
         return [AnyType()]
     else:
@@ -138,9 +140,10 @@ def dedupe_types(types):
 
 def filter_ignored_items(items):
      # type: (List[AbstractType]) -> List[AbstractType]
-    return [item for item in items
-            if not isinstance(item, ClassType) or
-            item.name not in IGNORED_ITEMS]
+    result = [item for item in items
+              if not isinstance(item, ClassType) or
+              item.name not in IGNORED_ITEMS]
+    return result or [AnyType()]
 
 def remove_redundant_items(items):
     # type: (List[AbstractType]) -> List[AbstractType]

--- a/pyannotate_tools/annotations/tests/infer_test.py
+++ b/pyannotate_tools/annotations/tests/infer_test.py
@@ -71,6 +71,13 @@ class TestInfer(unittest.TestCase):
                            ([(ClassType('Dict', [ClassType('str'), AnyType()]), ARG_POS)],
                             ClassType('None')))
 
+    def test_remove_redundant_dict_item_when_simplified(self):
+        # type: () -> None
+        self.assert_infer(['(Dict[str, Any]) -> None',
+                            '(Dict[str, Union[str, List, Dict, int]]) -> None'],
+                            ([(ClassType('Dict', [ClassType('str'), AnyType()]), ARG_POS)],
+                            ClassType('None')))
+
     def test_simplify_list_item_types(self):
         # type: () -> None
         self.assert_infer(['(List[Union[bool, int]]) -> None'],
@@ -114,6 +121,13 @@ class TestInfer(unittest.TestCase):
                            '(str) -> None'],
                            ([(ClassType('str'), ARG_POS)],
                             ClassType('None')))
+
+    def test_infer_ignore_mock_fallback_to_any(self):
+        # type: () -> None
+        self.assert_infer(['(mock.mock.Mock) -> str',
+                           '(mock.mock.Mock) -> int'],
+                           ([(AnyType(), ARG_POS)],
+                            UnionType([ClassType('str'), ClassType('int')])))
 
 CT = ClassType
 


### PR DESCRIPTION
This also fixes a problem when `filter_ignored_items` removes _all_
items the type was `Union[]`.  We fall back to `Any` now instead.