### PR TITLE
Treat any instance of a `Mapping` as a `Dict`.

### DIFF
--- a/pyannotate_runtime/collect_types.py
+++ b/pyannotate_runtime/collect_types.py
@@ -448,7 +448,7 @@ def resolve_type(arg):
         assert isinstance(arg, tuple)  # this line helps mypy figure out types
         sample = list(arg[:min(10, len(arg))])
         return TupleType([resolve_type(sample_item) for sample_item in sample])
-    elif arg_type == dict:
+    elif isinstance(arg, collections.Mapping):
         assert isinstance(arg, dict)  # this line helps mypy figure out types
         key_tt = TentativeType()
         val_tt = TentativeType()

--- a/pyannotate_runtime/collect_types.py
+++ b/pyannotate_runtime/collect_types.py
@@ -448,7 +448,7 @@ def resolve_type(arg):
         assert isinstance(arg, tuple)  # this line helps mypy figure out types
         sample = list(arg[:min(10, len(arg))])
         return TupleType([resolve_type(sample_item) for sample_item in sample])
-    elif isinstance(arg, collections.Mapping):
+    elif arg_type in {dict, collections.defaultdict, collections.OrderedDict}:
         assert isinstance(arg, dict)  # this line helps mypy figure out types
         key_tt = TentativeType()
         val_tt = TentativeType()

--- a/pyannotate_runtime/tests/test_collect_types.py
+++ b/pyannotate_runtime/tests/test_collect_types.py
@@ -11,7 +11,7 @@ import os
 import sched
 import time
 import unittest
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 from threading import Thread
 
 from six import PY2
@@ -170,6 +170,9 @@ def two_dict_comprehensions():
         for i, j in d.items()
     }
 
+def ordered_dict_as_dict():
+    # type: () -> Dict[str, int]
+    return OrderedDict([('a', 1), ('b', 2)])
 
 class TestBaseClass(unittest.TestCase):
 
@@ -578,6 +581,13 @@ class TestCollectTypes(TestBaseClass):
             (lambda x: x)(0)
             (lambda x, y: x+y)(0, 0)
         assert self.stats == []
+
+    def test_ordered_dict_treated_as_dict(self):
+        # type: () -> None
+        with self.collecting_types():
+            ordered_dict_as_dict()
+        self.assert_type_comments('ordered_dict_as_dict',
+                                  ['() -> Dict[str, int]'])
 
 
 def foo(arg):


### PR DESCRIPTION
Without this we're winding up with a bunch types like:

```
Union[Dict[str, str], OrderedDict]
```

On functions that can accept any `Mapping`.

I was woried about covariance/contravariance with this and `mypy` seems to be OK with that:

```python
from collections import OrderedDict
from typing import Dict

def foo(a: Dict[str, str]) -> Dict[str, str]:
    return OrderedDict([('a', 'a'), ('b', 'b')])

foo(OrderedDict([('a', 'a'), ('b', 'b')]))
```