### PR TITLE
Add basic AppVeyor config and fix Windows bugs in tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 environment:
   matrix:
+    - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python36-x64"
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,12 @@
+environment:
+  matrix:
+    - PYTHON: "C:\\Python36-x64"
+
+build: off
+
+install:
+    - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
+    - "%PYTHON%\\python.exe -m pip list"
+
+test_script:
+    - "%PYTHON%\\python.exe -m pytest"

--- a/pyannotate_tools/annotations/tests/dundermain_test.py
+++ b/pyannotate_tools/annotations/tests/dundermain_test.py
@@ -22,17 +22,15 @@ from pyannotate_tools.annotations.__main__ import main as dunder_main
 class TestDunderMain(unittest.TestCase):
     def setUp(self):
         # type: () -> None
-        self.tempdir = tempfile.gettempdir()
+        self.tempdir = tempfile.TemporaryDirectory()
         self.tempfiles = []  # type: List[str]
         self.olddir = os.getcwd()
-        os.chdir(self.tempdir)
+        os.chdir(self.tempdir.name)
 
     def tearDown(self):
         # type: () -> None
-        for tfn in reversed(self.tempfiles):
-            if os.path.isfile(tfn):
-                os.remove(tfn)
         os.chdir(self.olddir)
+        self.tempdir.cleanup()
 
     def write_file(self, name, data):
         # type: (str, str) -> None

--- a/pyannotate_tools/annotations/tests/dundermain_test.py
+++ b/pyannotate_tools/annotations/tests/dundermain_test.py
@@ -3,6 +3,7 @@
 import json
 import os
 import re
+import shutil
 import sys
 import tempfile
 import unittest
@@ -22,15 +23,15 @@ from pyannotate_tools.annotations.__main__ import main as dunder_main
 class TestDunderMain(unittest.TestCase):
     def setUp(self):
         # type: () -> None
-        self.tempdir = tempfile.TemporaryDirectory()
+        self.tempdirname = tempfile.mkdtemp()
         self.tempfiles = []  # type: List[str]
         self.olddir = os.getcwd()
-        os.chdir(self.tempdir.name)
+        os.chdir(self.tempdirname)
 
     def tearDown(self):
         # type: () -> None
         os.chdir(self.olddir)
-        self.tempdir.cleanup()
+        shutil.rmtree(self.tempdirname)
 
     def write_file(self, name, data):
         # type: (str, str) -> None

--- a/pyannotate_tools/annotations/tests/parse_test.py
+++ b/pyannotate_tools/annotations/tests/parse_test.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import unittest
 
@@ -40,11 +41,14 @@ class TestParseJson(unittest.TestCase):
             }
         ]
         """
-        with tempfile.NamedTemporaryFile(mode='w') as f:
-            f.write(data)
-            f.flush()
-
+        f = None
+        try:
+            with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+                f.write(data)
             result = parse_json(f.name)
+        finally:
+            if f is not None:
+                os.remove(f.name)
         assert len(result) == 1
         item = result[0]
         assert item.path == 'pkg/thing.py'

--- a/pyannotate_tools/fixes/tests/test_annotate_json.py
+++ b/pyannotate_tools/fixes/tests/test_annotate_json.py
@@ -2,6 +2,7 @@
 # Our flake extension misfires on type comments in strings below.
 
 import json
+import os
 import tempfile
 
 from lib2to3.tests.test_fixers import FixerTestCase
@@ -16,7 +17,8 @@ class TestFixAnnotateJson(FixerTestCase):
             fix_list=["annotate_json"],
             fixer_pkg="pyannotate_tools",
         )
-        self.tf = tempfile.NamedTemporaryFile(mode='w+')
+        # See https://bugs.python.org/issue14243 for details
+        self.tf = tempfile.NamedTemporaryFile(mode='w', delete=False)
         FixAnnotateJson.stub_json_file = self.tf.name
         FixAnnotateJson.stub_json = None
 
@@ -24,11 +26,12 @@ class TestFixAnnotateJson(FixerTestCase):
         FixAnnotateJson.stub_json = None
         FixAnnotateJson.stub_json_file = None
         self.tf.close()
+        os.remove(self.tf.name)
         super(TestFixAnnotateJson, self).tearDown()
 
     def setTestData(self, data):
         json.dump(data, self.tf)
-        self.tf.flush()
+        self.tf.close()
         self.filename = data[0]["path"]
 
     def test_basic(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-mypy_extensions
-pytest
-setuptools
-six
-typing
+mypy_extensions>=0.3.0
+pytest>=3.3.0
+setuptools>=28.8.0
+six>=1.11.0
+typing>=3.6.2; python_version < '3.5'


### PR DESCRIPTION
All uses of NamedTemporaryFile were wrong; see https://bugs.python.org/issue14243 for details.
Also I had misunderstood gettempdir -- replace that with mkdtemp.