### PR TITLE
Fix types declared in unknown modules

### DIFF
--- a/pyannotate_runtime/collect_types.py
+++ b/pyannotate_runtime/collect_types.py
@@ -350,9 +350,10 @@ def name_from_type(type_):
     else:
         if type_.__name__ != 'NoneType':
             module = type_.__module__
-            if module in BUILTIN_MODULES:
+            if module in BUILTIN_MODULES or module == '<unknown>':
                 # Omit module prefix for known built-ins, for convenience. This
                 # makes unit tests for this module simpler.
+                # Also ignore '<uknown>' modules so pyannotate can parse these types
                 return type_.__name__
             else:
                 return '%s.%s' % (module, type_.__name__)

--- a/pyannotate_runtime/tests/test_collect_types.py
+++ b/pyannotate_runtime/tests/test_collect_types.py
@@ -588,7 +588,7 @@ class TestCollectTypes(TestBaseClass):
         with self.collecting_types():
             ns = {
                 '__name__': '<unknown>'
-            }
+            }   # type: Dict[str, Any]
             exec('class C(object): pass', ns)
 
             func_with_unknown_module_types(ns['C']())

--- a/pyannotate_runtime/tests/test_collect_types.py
+++ b/pyannotate_runtime/tests/test_collect_types.py
@@ -579,6 +579,22 @@ class TestCollectTypes(TestBaseClass):
             (lambda x, y: x+y)(0, 0)
         assert self.stats == []
 
+    def test_unknown_module_types(self):
+        # type: () -> None
+        def func_with_unknown_module_types(c):
+            # type: (Any) -> Any
+            return c
+
+        with self.collecting_types():
+            ns = {
+                '__name__': '<unknown>'
+            }
+            exec('class C(object): pass', ns)
+
+            func_with_unknown_module_types(ns['C']())
+
+        self.assert_type_comments('func_with_unknown_module_types', ['(C) -> C'])
+
 
 def foo(arg):
     # type: (Any) -> Any


### PR DESCRIPTION
If types collector can't find a module where the type was declared, it stores the type as `<unknown>`.TypeName. pyannotate tool fails to process this kind of type comments.
Let's just skip the `<unknown>` prefix