### PR TITLE
Turn a .remove() into a .discard() to avoid race conditions

### DIFF
--- a/pyannotate_runtime/collect_types.py
+++ b/pyannotate_runtime/collect_types.py
@@ -832,7 +832,7 @@ def _trace_dispatch(frame, event, arg):
             # No pending call event -- ignore this event. We only collect
             # return events when we know the corresponding call event.
             return
-        call_pending.remove(key)
+        call_pending.discard(key)  # Avoid race conditions
     else:
         # Ignore other events, such as c_call and c_return.
         return


### PR DESCRIPTION
It is apparently possible for multiple threads to reach the same point in the code, both will see `event == 'return'` and `key in call_pending` and then both will attempt to remove the pending call.

Hopefully the background thread processing the queue isn't too confused by the duplicated events.