### PR TITLE
Add a flag to pyannotate to start with simple types.

### DIFF
--- a/pyannotate_tools/annotations/__main__.py
+++ b/pyannotate_tools/annotations/__main__.py
@@ -33,7 +33,7 @@ parser.add_argument('-a', '--auto-any', action='store_true',
 parser.add_argument('files', nargs='*', metavar="FILE",
                     help="Files and directories to update with annotations")
 parser.add_argument('-s', '--only-simple', action='store_true',
-                    help="Only annotate functions with trivial types.")
+                    help="Only annotate functions with trivial types")
 
 
 class ModifiedRefactoringTool(StdoutRefactoringTool):

--- a/pyannotate_tools/annotations/__main__.py
+++ b/pyannotate_tools/annotations/__main__.py
@@ -32,6 +32,8 @@ parser.add_argument('-a', '--auto-any', action='store_true',
                     help="Annotate everything with 'Any', without reading type_info.json")
 parser.add_argument('files', nargs='*', metavar="FILE",
                     help="Files and directories to update with annotations")
+parser.add_argument('-s', '--only-simple', action='store_true',
+                    help="Only annotate functions with trivial types.")
 
 
 class ModifiedRefactoringTool(StdoutRefactoringTool):
@@ -93,7 +95,8 @@ def main(args_override=None):
         return
 
     # Run pass 2 with output into a variable.
-    data = generate_annotations_json_string(args.type_info)  # type: List[Any]
+    data = generate_annotations_json_string(args.type_info,
+                                            only_simple=args.only_simple)  # type: List[Any]
 
     # Run pass 3 with input from that variable.
     if args.auto_any:

--- a/pyannotate_tools/annotations/main.py
+++ b/pyannotate_tools/annotations/main.py
@@ -58,7 +58,7 @@ def generate_annotations_json_string(source_path, only_simple=False):
     results = []
     for item in items:
         signature = unify_type_comments(item.type_comments)
-        if not only_simple or is_signature_simple(signature):
+        if is_signature_simple(signature) or not only_simple:
             data = {
                 'path': item.path,
                 'line': item.line,

--- a/pyannotate_tools/annotations/tests/main_test.py
+++ b/pyannotate_tools/annotations/tests/main_test.py
@@ -109,6 +109,52 @@ class TestMain(unittest.TestCase):
             }
         ]
 
+        with self.temporary_json_file(data) as source_path:
+            output_data = generate_annotations_json_string(source_path, only_simple=True)
+        assert output_data == []
+
+    def test_generate_simple_signatures(self):
+        # type: () -> None
+        data = """
+        [
+            {
+                "path": "pkg/thing.py",
+                "line": 422,
+                "func_name": "complex_function",
+                "type_comments": [
+                    "(List[int], str) -> None"
+                ],
+                "samples": 3
+            },
+            {
+                "path": "pkg/thing.py",
+                "line": 9000,
+                "func_name": "simple_function",
+                "type_comments": [
+                    "(int, str) -> None"
+                ],
+                "samples": 3
+            }
+        ]
+        """
+        with self.temporary_json_file(data) as source_path:
+            output_data = generate_annotations_json_string(source_path, only_simple=True)
+        assert output_data == [
+            {
+                "path": "pkg/thing.py",
+                "line": 9000,
+                "func_name": "simple_function",
+                "signature": {
+                    "arg_types": [
+                        "int",
+                        "str"
+                    ],
+                    "return_type": "None"
+                },
+                "samples": 3
+            }
+        ]
+
     @contextlib.contextmanager
     def temporary_json_file(self, data):
         # type: (str) -> Iterator[str]


### PR DESCRIPTION
As we continue to adopt types here at Lyft we'd like the ability to
first type trivially typable functions (like `() -> None`) first, and
then work our way up to Unions/Generics etc...

This PR adds a flag to enable this.