### PR TITLE
Assume any arguments typed `None` are `Optional[Any]` instead.

### DIFF
--- a/pyannotate_tools/annotations/infer.py
+++ b/pyannotate_tools/annotations/infer.py
@@ -54,6 +54,10 @@ def infer_annotation(type_comments):
             raise InferError('Ambiguous argument kinds:\n' + '\n'.join(type_comments))
         types = [arg.type for arg in arg_infos]
         combined = combine_types(types)
+        if str(combined) == 'None':
+            # It's very rare for an argument to actually be typed `None`, more likely than
+            # not we simply don't have any data points for this argument.
+            combined = UnionType([ClassType('None'), AnyType()])
         if kind != ARG_POS and (len(str(combined)) > 120 or isinstance(combined, UnionType)):
             # Avoid some noise.
             combined = AnyType()

--- a/pyannotate_tools/annotations/tests/infer_test.py
+++ b/pyannotate_tools/annotations/tests/infer_test.py
@@ -130,6 +130,12 @@ class TestInfer(unittest.TestCase):
                            ([(AnyType(), ARG_POS)],
                             UnionType([ClassType('str'), ClassType('int')])))
 
+    def test_infer_none_argument(self):
+        # type: () -> None
+        self.assert_infer(['(None) -> None'],
+                           ([(UnionType([ClassType('None'), AnyType()]), ARG_POS)],
+                            ClassType('None')))
+
 CT = ClassType
 
 


### PR DESCRIPTION
We've had a few instances where pyannotate marks a keyword argument as having
type `None` since it hadn't observed any instances of that value being passed in,
but none of those instances have been correct.  It would be safer to assume the
type is `Optional[Any]`.