### PR TITLE
Replace resume()/pause() by start()/stop()

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,19 @@ Phase 1: Collecting types at runtime
 - Install the usual way (see "red tape" section below)
 - Add `from pyannotate_runtime import collect_types` to your test
 - Early in your test setup, call `collect_types.init_types_collection()`
-- Bracket your test code between calls to `collect_types.resume()` and
-  `collect_types.pause()` (or use the context manager below)
+- Bracket your test execution between calls to `collect_types.start()` and
+  `collect_types.stop()` (or use the context manager below)
 - When done, call `collect_types.dump_stats(filename)`
 
-All calls between the `resume()` and `pause()` calls will be analyzed
+All calls between the `start()` and `stop()` calls will be analyzed
 and the observed types will be written (in JSON form) to the filename
-you pass to `dump_stats()`.  You can have multiple pause/resume pairs
+you pass to `dump_stats()`.  You can have multiple start/stop pairs
 per dump call.
 
 If you'd like to automatically collect types when you run `pytest`,
 see `example/example_conftest.py` and `example/README.md`.
 
-Instead of using `resume()` and `pause()` you can also use a context
+Instead of using `start()` and `stop()` you can also use a context
 manager:
 ```
 collect_types.init_types_collection()

--- a/example/example_conftest.py
+++ b/example/example_conftest.py
@@ -18,9 +18,9 @@ def pytest_collection_finish(session):
 @pytest.fixture(autouse=True)
 def collect_types_fixture():
     from pyannotate_runtime import collect_types
-    collect_types.resume()
+    collect_types.start()
     yield
-    collect_types.pause()
+    collect_types.stop()
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/pyannotate_runtime/collect_types.py
+++ b/pyannotate_runtime/collect_types.py
@@ -8,11 +8,11 @@ type info about arguments and return type.
 
 For the module consumer, the workflow looks like that:
 1) call init_types_collection() from the main thread once
-2) call resume() to start the type collection
-3) call pause() to stop the type collection
+2) call start() to start the type collection
+3) call stop() to stop the type collection
 4) call dump_stats(file_name) to dump all collected info to the file as json
 
-You can repeat resume() / pause() as many times as you want.
+You can repeat start() / stop() as many times as you want.
 
 The module is based on Tony's 2016 prototype D219371.
 """
@@ -733,17 +733,25 @@ call_pending = set()  # type: Set[int]
 @contextmanager
 def collect():
     # type: () -> Iterator[None]
-    resume()
+    start()
     try:
         yield
     finally:
-        pause()
+        stop()
 
 
 def pause():
     # type: () -> None
     """
-    Pause the type collection
+    Deprecated, replaced by stop().
+    """
+    # In the future, do: warnings.warn("Function pause() has been replaced by start().", PendingDeprecationWarning)
+    return stop()
+
+def stop():
+    # type: () -> None
+    """
+    Start collecting type information.
     """
     global running  # pylint: disable=global-statement
     running = False
@@ -753,7 +761,15 @@ def pause():
 def resume():
     # type: () -> None
     """
-    Resume the type collection
+    Deprecated, replaced by start().
+    """
+    # In the future, do: warnings.warn("Function resume() has been replaced by stop().", PendingDeprecationWarning)
+    return start()
+
+def start():
+    # type: () -> None
+    """
+    Stop collecting type information.
     """
     global running  # pylint: disable=global-statement
     running = True

--- a/pyannotate_runtime/tests/test_collect_types.py
+++ b/pyannotate_runtime/tests/test_collect_types.py
@@ -195,9 +195,9 @@ class TestBaseClass(unittest.TestCase):
         collect_types.num_samples = {}
         collect_types.sampling_counters = {}
         collect_types.call_pending = set()
-        collect_types.resume()
+        collect_types.start()
         yield None
-        collect_types.pause()
+        collect_types.stop()
         self.load_stats()
 
     def assert_type_comments(self, func_name, comments):
@@ -437,11 +437,11 @@ class TestCollectTypes(TestBaseClass):
 
         def only_return(x):
             # type: (int) -> str
-            collect_types.resume()
+            collect_types.start()
             return ''
 
         only_return(1)
-        collect_types.pause()
+        collect_types.stop()
         self.load_stats()
         # No entry is stored if we only have a return event with no matching call.
         self.assert_type_comments('only_return', [])


### PR DESCRIPTION
I let you see if you want to warn with a PendingDeprecationWarning. For me, it's not necessary, this is just a cosmetic change.

There is no longer any test for the pause/resume version, which is less than ideal but the code review seems enough to catch for accidental removal should there be any in the future.
