### PR TITLE
Python3 annotations

### DIFF
--- a/pyannotate_tools/annotations/__main__.py
+++ b/pyannotate_tools/annotations/__main__.py
@@ -35,12 +35,12 @@ parser.add_argument('files', nargs='*', metavar="FILE",
 parser.add_argument('-s', '--only-simple', action='store_true',
                     help="Only annotate functions with trivial types")
 parser.add_argument('--python-version', action='store', default='2',
-                    help='''Choose annotation style, 2 for Python 2 with comments (the 
-                         default), 3 for Python 3 with direct annotation''' )
+                    help="Choose annotation style, 2 for Python 2 with comments (the "
+                         "default), 3 for Python 3 with annotation syntax" )
 parser.add_argument('--py2', '-2', action='store_const', dest='python_version', const='2',
-                    help='''Annotate for Python 2 with comments (default)''')
+                    help="Annotate for Python 2 with comments (default)")
 parser.add_argument('--py3', '-3', action='store_const', dest='python_version', const='3',
-                    help='''Annotate for Python 3 with argument and return value annotations''')
+                    help="Annotate for Python 3 with argument and return value annotations")
 
 
 class ModifiedRefactoringTool(StdoutRefactoringTool):

--- a/pyannotate_tools/annotations/__main__.py
+++ b/pyannotate_tools/annotations/__main__.py
@@ -34,6 +34,13 @@ parser.add_argument('files', nargs='*', metavar="FILE",
                     help="Files and directories to update with annotations")
 parser.add_argument('-s', '--only-simple', action='store_true',
                     help="Only annotate functions with trivial types")
+parser.add_argument('--python-version', action='store',
+                    help='''Choose annotation style, 2 for Python 2 with comments (the 
+                         default), 3 for Python 3 with direct annotation''' )
+parser.add_argument('--py2', '-2', action='store_true',
+                    help='''Annotate for Python 2 with comments (default)''')
+parser.add_argument('--py3', '-3', action='store_true',
+                    help='''Annotate for Python 3 with argument and return value annotations''')
 
 
 class ModifiedRefactoringTool(StdoutRefactoringTool):
@@ -86,6 +93,16 @@ def main(args_override=None):
     except OSError as err:
         sys.exit("Can't open type info file: %s" % err)
 
+    if args.python_version not in (None, '2','3'):
+        sys.exit('--python-version must be 2 or 3')
+
+    if (args.py2 and args.py3) or (args.py2 and args.python_version) or (args.py3 and args.python_version):
+        sys.exit('You can not use multiple annotation version specifier')
+
+    annotation_style = 'py2'
+    if args.py3 or args.python_version == '3':
+        annotation_style = 'py3'
+
     # Set up logging handler.
     level = logging.DEBUG if args.verbose else logging.INFO
     logging.basicConfig(format='%(message)s', level=level)
@@ -104,7 +121,7 @@ def main(args_override=None):
     else:
         FixAnnotateJson.init_stub_json_from_data(data, args.files[0])
         fixers = ['pyannotate_tools.fixes.fix_annotate_json']
-    flags = {'print_function': args.print_function}
+    flags = {'print_function': args.print_function, 'annotation_style': annotation_style}
     rt = ModifiedRefactoringTool(
         fixers=fixers,
         options=flags,

--- a/pyannotate_tools/annotations/__main__.py
+++ b/pyannotate_tools/annotations/__main__.py
@@ -116,7 +116,8 @@ def main(args_override=None):
     else:
         FixAnnotateJson.init_stub_json_from_data(data, args.files[0])
         fixers = ['pyannotate_tools.fixes.fix_annotate_json']
-    flags = {'print_function': args.print_function, 'annotation_style': annotation_style}
+    flags = {'print_function': args.print_function,
+             'annotation_style': annotation_style}
     rt = ModifiedRefactoringTool(
         fixers=fixers,
         options=flags,

--- a/pyannotate_tools/annotations/__main__.py
+++ b/pyannotate_tools/annotations/__main__.py
@@ -34,12 +34,12 @@ parser.add_argument('files', nargs='*', metavar="FILE",
                     help="Files and directories to update with annotations")
 parser.add_argument('-s', '--only-simple', action='store_true',
                     help="Only annotate functions with trivial types")
-parser.add_argument('--python-version', action='store',
+parser.add_argument('--python-version', action='store', default='2',
                     help='''Choose annotation style, 2 for Python 2 with comments (the 
                          default), 3 for Python 3 with direct annotation''' )
-parser.add_argument('--py2', '-2', action='store_true',
+parser.add_argument('--py2', '-2', action='store_const', dest='python_version', const='2',
                     help='''Annotate for Python 2 with comments (default)''')
-parser.add_argument('--py3', '-3', action='store_true',
+parser.add_argument('--py3', '-3', action='store_const', dest='python_version', const='3',
                     help='''Annotate for Python 3 with argument and return value annotations''')
 
 
@@ -93,15 +93,10 @@ def main(args_override=None):
     except OSError as err:
         sys.exit("Can't open type info file: %s" % err)
 
-    if args.python_version not in (None, '2','3'):
+    if args.python_version not in ('2', '3'):
         sys.exit('--python-version must be 2 or 3')
 
-    if (args.py2 and args.py3) or (args.py2 and args.python_version) or (args.py3 and args.python_version):
-        sys.exit('You can not use multiple annotation version specifier')
-
-    annotation_style = 'py2'
-    if args.py3 or args.python_version == '3':
-        annotation_style = 'py3'
+    annotation_style = 'py' + args.python_version
 
     # Set up logging handler.
     level = logging.DEBUG if args.verbose else logging.INFO

--- a/pyannotate_tools/fixes/fix_annotate.py
+++ b/pyannotate_tools/fixes/fix_annotate.py
@@ -99,7 +99,7 @@ class FixAnnotate(BaseFix):
 
         # Python 3 style return annotation are already skipped by the pattern
 
-        ### Python 3 style argument annotation
+        ### Python 3 style argument annotation structure
         #
         # Structure of the arguments tokens for one positional argument without default value :
         # + LPAR '('
@@ -177,9 +177,9 @@ class FixAnnotate(BaseFix):
         argtypes, restype = annot
 
         if self.options['annotation_style'] == 'py3':
-            self.add_py3_annot( argtypes, restype, node, results)
+            self.add_py3_annot(argtypes, restype, node, results)
         else:
-            self.add_py2_annot( argtypes, restype, node, results)
+            self.add_py2_annot(argtypes, restype, node, results)
 
         # Common to py2 and py3 style annotations:
         if FixAnnotate.counter is not None:
@@ -188,8 +188,7 @@ class FixAnnotate(BaseFix):
         # Also add 'from typing import Any' at the top if needed.
         self.patch_imports(argtypes + [restype], node)
 
-
-    def add_py3_annot( self, argtypes, restype, node, results):
+    def add_py3_annot(self, argtypes, restype, node, results):
         args = results.get('args')
 
         argleaves = []
@@ -198,7 +197,7 @@ class FixAnnotate(BaseFix):
             it = iter([])
         elif len(args.children) == 0:
             # function with 1 argument
-            it = iter( [ args ] )
+            it = iter([args])
         else:
             # function with multiple arguments or 1 arg with default value
             it = iter(args.children)
@@ -216,7 +215,7 @@ class FixAnnotate(BaseFix):
                 argstyle = 'keyword'
                 ch = next(it)
             assert ch.type == token.NAME
-            argleaves.append( (argstyle, ch) )
+            argleaves.append((argstyle, ch))
             try:
                 ch = next(it)
                 if ch.type == token.EQUAL:
@@ -228,7 +227,7 @@ class FixAnnotate(BaseFix):
                 break
 
         # when self or cls is not annotated, argleaves == argtypes+1
-        argleaves = argleaves[ len(argleaves)-len(argtypes): ]
+        argleaves = argleaves[len(argleaves) - len(argtypes):]
 
         for ch_withstyle, chtype in zip(argleaves, argtypes):
             style, ch = ch_withstyle
@@ -258,19 +257,18 @@ class FixAnnotate(BaseFix):
 
         rpar.changed()
 
-    def add_py2_annot( self, argtypes, restype, node, results):
-        ### Python 2 style annotation
-        #
+    def add_py2_annot(self, argtypes, restype, node, results):
         children = results['suite'][0].children
 
         # Insert '# type: {annot}' comment.
         # For reference, see lib2to3/fixes/fix_tuple_params.py in stdlib.
         if len(children) >= 1 and children[0].type != token.NEWLINE:
-                # one liner function
+            # one liner function
             if children[0].prefix.strip() == '':
                 children[0].prefix = ''
                 children.insert(0, Leaf(token.NEWLINE, '\n'))
-                children.insert(1, Leaf(token.INDENT, find_indentation(node) + '    '))
+                children.insert(
+                    1, Leaf(token.INDENT, find_indentation(node) + '    '))
                 children.append(Leaf(token.DEDENT, ''))
         if len(children) >= 2 and children[1].type == token.INDENT:
             degen_str = '(...) -> %s' % restype
@@ -383,7 +381,7 @@ class FixAnnotate(BaseFix):
                     else:
                         # Always skip the first argument if it's named 'self'.
                         # Always skip the first argument of a class method.
-                        if  child.value == 'self' or 'classmethod' in decorators:
+                        if child.value == 'self' or 'classmethod' in decorators:
                             pass
                         else:
                             inferred_type = 'Any'

--- a/pyannotate_tools/fixes/fix_annotate.py
+++ b/pyannotate_tools/fixes/fix_annotate.py
@@ -5,15 +5,14 @@ This transforms e.g.
   def foo(self, bar, baz=12):
       return bar + baz
 
-into:
+into a type annoted version:
 
-- with options {'annotation_style'='py2'} :
 	  def foo(self, bar, baz=12):
 	      # type: (Any, int) -> Any            # noqa: F821
 	      return bar + baz
 
+or (when setting options['annotation_style'] to 'py3'):
 
-- with options {'annotation_style'='py3'} :
 	  def foo(self, bar : Any, baz : int=12) -> Any:
 	      return bar + baz
 

--- a/pyannotate_tools/fixes/fix_annotate.py
+++ b/pyannotate_tools/fixes/fix_annotate.py
@@ -5,11 +5,18 @@ This transforms e.g.
   def foo(self, bar, baz=12):
       return bar + baz
 
-into
+into:
 
-  def foo(self, bar, baz=12):
-      # type: (Any, int) -> Any            # noqa: F821
-      return bar + baz
+- with options {'annotation_style'='py2'} :
+	  def foo(self, bar, baz=12):
+	      # type: (Any, int) -> Any            # noqa: F821
+	      return bar + baz
+
+
+- with options {'annotation_style'='py3'} :
+	  def foo(self, bar : Any, baz : int=12) -> Any:
+	      return bar + baz
+
 
 It does not do type inference but it recognizes some basic default
 argument values such as numbers and strings (and assumes their type
@@ -46,7 +53,7 @@ class FixAnnotate(BaseFix):
 
     # The pattern to match.
     PATTERN = """
-              funcdef< 'def' name=any parameters=parameters< '(' [args=any] ')' > ':' suite=any+ >
+              funcdef< 'def' name=any parameters=parameters< '(' [args=any] rpar=')' > ':' suite=any+ >
               """
 
     _maxfixes = os.getenv('MAXFIXES')
@@ -69,8 +76,7 @@ class FixAnnotate(BaseFix):
                 if ch.prefix.lstrip().startswith('# type:'):
                     return
 
-        suite = results['suite']
-        children = suite[0].children
+        children = results['suite'][0].children
 
         # NOTE: I've reverse-engineered the structure of the parse tree.
         # It's always a list of nodes, the first of which contains the
@@ -91,21 +97,182 @@ class FixAnnotate(BaseFix):
             if ch.prefix.lstrip().startswith('# type:'):
                 return  # There's already a # type: comment here; don't change anything.
 
+        # Python 3 style return annotation are already skipped by the pattern
+
+        ### Python 3 style argument annotation
+        #
+        # Structure of the arguments tokens for one positional argument without default value :
+        # + LPAR '('
+        # + NAME_NODE_OR_LEAF arg1
+        # + RPAR ')'
+        #
+        # NAME_NODE_OR_LEAF is either:
+        # 1. Just a leaf with value NAME
+        # 2. A node with children: NAME, ':", node expr or value leaf
+        #
+        # Structure of the arguments tokens for one args with default value or multiple
+        # args, with or without default value, and/or with extra arguments :
+        # + LPAR '('
+        # + node
+        #   [
+        #     + NAME_NODE_OR_LEAF
+        #      [
+        #        + EQUAL '='
+        #        + node expr or value leaf
+        #      ]
+        #    (
+        #        + COMMA ','
+        #        + NAME_NODE_OR_LEAF positional argn
+        #      [
+        #        + EQUAL '='
+        #        + node expr or value leaf
+        #      ]
+        #    )*
+        #   ]
+        #   [
+        #     + STAR '*'
+        #     [
+        #     + NAME_NODE_OR_LEAF positional star argument name
+        #     ]
+        #   ]
+        #   [
+        #     + COMMA ','
+        #     + DOUBLESTAR '**'
+        #     + NAME_NODE_OR_LEAF positional keyword argument name
+        #   ]
+        # + RPAR ')'
+
+        # Let's skip Python 3 argument annotations
+        it = iter(args.children) if args else iter([])
+        for ch in it:
+            if ch.type == token.STAR:
+                # *arg part
+                ch = next(it)
+                if ch.type == token.COMMA:
+                    continue
+            elif ch.type == token.DOUBLESTAR:
+                # *arg part
+                ch = next(it)
+            if ch.type > 256:
+                # this is a node, therefore an annotation
+                assert ch.children[0].type == token.NAME
+                return
+            try:
+                ch = next(it)
+                if ch.type == token.COLON:
+                    # this is an annotation
+                    return
+                elif ch.type == token.EQUAL:
+                    ch = next(it)
+                    ch = next(it)
+                assert ch.type == token.COMMA
+                continue
+            except StopIteration:
+                break
+
         # Compute the annotation
         annot = self.make_annotation(node, results)
         if annot is None:
             return
+        argtypes, restype = annot
+
+        if self.options['annotation_style'] == 'py3':
+            self.add_py3_annot( argtypes, restype, node, results)
+        else:
+            self.add_py2_annot( argtypes, restype, node, results)
+
+        # Common to py2 and py3 style annotations:
+        if FixAnnotate.counter is not None:
+            FixAnnotate.counter -= 1
+
+        # Also add 'from typing import Any' at the top if needed.
+        self.patch_imports(argtypes + [restype], node)
+
+
+    def add_py3_annot( self, argtypes, restype, node, results):
+        args = results.get('args')
+
+        argleaves = []
+        if args is None:
+            # function with 0 arguments
+            it = iter([])
+        elif len(args.children) == 0:
+            # function with 1 argument
+            it = iter( [ args ] )
+        else:
+            # function with multiple arguments or 1 arg with default value
+            it = iter(args.children)
+
+        for ch in it:
+            argstyle = 'name'
+            if ch.type == token.STAR:
+                # *arg part
+                argstyle = 'star'
+                ch = next(it)
+                if ch.type == token.COMMA:
+                    continue
+            elif ch.type == token.DOUBLESTAR:
+                # *arg part
+                argstyle = 'keyword'
+                ch = next(it)
+            assert ch.type == token.NAME
+            argleaves.append( (argstyle, ch) )
+            try:
+                ch = next(it)
+                if ch.type == token.EQUAL:
+                    ch = next(it)
+                    ch = next(it)
+                assert ch.type == token.COMMA
+                continue
+            except StopIteration:
+                break
+
+        # when self or cls is not annotated, argleaves == argtypes+1
+        argleaves = argleaves[ len(argleaves)-len(argtypes): ]
+
+        for ch_withstyle, chtype in zip(argleaves, argtypes):
+            style, ch = ch_withstyle
+            if style == 'star':
+                assert chtype[0] == '*'
+                assert chtype[1] != '*'
+                chtype = chtype[1:]
+            elif style == 'keyword':
+                assert chtype[0:2] == '**'
+                assert chtype[2] != '*'
+                chtype = chtype[2:]
+            ch.value = '%s: %s' % (ch.value, chtype)
+
+            # put spaces around the equal sign
+            if ch.next_sibling and ch.next_sibling.type == token.EQUAL:
+                nextch = ch.next_sibling
+                if not nextch.prefix[:1].isspace():
+                    nextch.prefix = ' ' + nextch.prefix
+                nextch = nextch.next_sibling
+                assert nextch != None
+                if not nextch.prefix[:1].isspace():
+                    nextch.prefix = ' ' + nextch.prefix
+
+        # Add return annotation
+        rpar = results['rpar']
+        rpar.value = '%s -> %s' % (rpar.value, restype)
+
+        rpar.changed()
+
+    def add_py2_annot( self, argtypes, restype, node, results):
+        ### Python 2 style annotation
+        #
+        children = results['suite'][0].children
 
         # Insert '# type: {annot}' comment.
         # For reference, see lib2to3/fixes/fix_tuple_params.py in stdlib.
         if len(children) >= 1 and children[0].type != token.NEWLINE:
+                # one liner function
             if children[0].prefix.strip() == '':
                 children[0].prefix = ''
                 children.insert(0, Leaf(token.NEWLINE, '\n'))
                 children.insert(1, Leaf(token.INDENT, find_indentation(node) + '    '))
                 children.append(Leaf(token.DEDENT, ''))
         if len(children) >= 2 and children[1].type == token.INDENT:
-            argtypes, restype = annot
             degen_str = '(...) -> %s' % restype
             short_str = '(%s) -> %s' % (', '.join(argtypes), restype)
             if (len(short_str) > 64 or len(argtypes) > 5) and len(short_str) > len(degen_str):
@@ -116,11 +283,6 @@ class FixAnnotate(BaseFix):
             children[1].prefix = '%s# type: %s\n%s' % (children[1].value, annot_str,
                                                        children[1].prefix)
             children[1].changed()
-            if FixAnnotate.counter is not None:
-                FixAnnotate.counter -= 1
-
-            # Also add 'from typing import Any' at the top if needed.
-            self.patch_imports(argtypes + [restype], node)
         else:
             self.log_message("%s:%d: cannot insert annotation for one-line function" %
                              (self.filename, node.get_lineno()))

--- a/pyannotate_tools/fixes/fix_annotate.py
+++ b/pyannotate_tools/fixes/fix_annotate.py
@@ -13,7 +13,7 @@ into a type annoted version:
 
 or (when setting options['annotation_style'] to 'py3'):
 
-	  def foo(self, bar : Any, baz : int=12) -> Any:
+	  def foo(self, bar : Any, baz : int = 12) -> Any:
 	      return bar + baz
 
 

--- a/pyannotate_tools/fixes/tests/test_annotate_json_py2.py
+++ b/pyannotate_tools/fixes/tests/test_annotate_json_py2.py
@@ -1,0 +1,642 @@
+# flake8: noqa
+# Our flake extension misfires on type comments in strings below.
+
+import json
+import os
+import tempfile
+
+from lib2to3.tests.test_fixers import FixerTestCase
+
+from pyannotate_tools.fixes.fix_annotate_json import FixAnnotateJson
+
+
+class TestFixAnnotateJson(FixerTestCase):
+
+    def setUp(self):
+        super(TestFixAnnotateJson, self).setUp(
+            fix_list=["annotate_json"],
+            fixer_pkg="pyannotate_tools",
+            options={'annotation_style' : 'py2'},
+        )
+        # See https://bugs.python.org/issue14243 for details
+        self.tf = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        FixAnnotateJson.stub_json_file = self.tf.name
+        FixAnnotateJson.stub_json = None
+
+    def tearDown(self):
+        FixAnnotateJson.stub_json = None
+        FixAnnotateJson.stub_json_file = None
+        self.tf.close()
+        os.remove(self.tf.name)
+        super(TestFixAnnotateJson, self).tearDown()
+
+    def setTestData(self, data):
+        json.dump(data, self.tf)
+        self.tf.close()
+        self.filename = data[0]["path"]
+
+    def test_basic(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 3,
+              "signature": {
+                  "arg_types": ["Foo", "Bar"],
+                  "return_type": "Any"},
+              }])
+        a = """\
+            class Foo: pass
+            class Bar: pass
+            def nop(foo, bar):
+                return 42
+            """
+        b = """\
+            from typing import Any
+            class Foo: pass
+            class Bar: pass
+            def nop(foo, bar):
+                # type: (Foo, Bar) -> Any
+                return 42
+            """
+        self.check(a, b)
+
+    def test_keyword_only_argument(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 3,
+              "signature": {
+                  "arg_types": ["Foo", "Bar"],
+                  "return_type": "Any"},
+              }])
+        a = """\
+            class Foo: pass
+            class Bar: pass
+            def nop(foo, *, bar):
+                return 42
+            """
+        b = """\
+            from typing import Any
+            class Foo: pass
+            class Bar: pass
+            def nop(foo, *, bar):
+                # type: (Foo, Bar) -> Any
+                return 42
+            """
+        self.check(a, b)
+
+    def test_add_typing_import(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 1,
+              # Check with and without 'typing.' prefix
+              "signature": {
+                  "arg_types": ["List[typing.AnyStr]", "Callable[[], int]"],
+                  "return_type": "object"},
+              }])
+        a = """\
+            def nop(foo, bar):
+                return 42
+            """
+        b = """\
+            from typing import AnyStr
+            from typing import Callable
+            from typing import List
+            def nop(foo, bar):
+                # type: (List[AnyStr], Callable[[], int]) -> object
+                return 42
+            """
+        self.check(a, b)
+
+    def test_add_other_import(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "mod1.py",
+              "line": 1,
+              "signature": {
+                  "arg_types": ["mod1.MyClass", "mod2.OtherClass"],
+                  "return_type": "mod3.AnotherClass"},
+              }])
+        a = """\
+            def nop(foo, bar):
+                return AnotherClass()
+            class MyClass: pass
+            """
+        b = """\
+            from mod2 import OtherClass
+            from mod3 import AnotherClass
+            def nop(foo, bar):
+                # type: (MyClass, OtherClass) -> AnotherClass
+                return AnotherClass()
+            class MyClass: pass
+            """
+        self.check(a, b)
+
+    def test_add_kwds(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 1,
+              "signature": {
+                  "arg_types": ["int"],
+                  "return_type": "object"},
+              }])
+        a = """\
+            def nop(foo, **kwds):
+                return 42
+            """
+        b = """\
+            from typing import Any
+            def nop(foo, **kwds):
+                # type: (int, **Any) -> object
+                return 42
+            """
+        self.check(a, b)
+
+    def test_dont_add_kwds(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 1,
+              "signature": {
+                  "arg_types": ["int", "**AnyStr"],
+                  "return_type": "object"},
+              }])
+        a = """\
+            def nop(foo, **kwds):
+                return 42
+            """
+        b = """\
+            from typing import AnyStr
+            def nop(foo, **kwds):
+                # type: (int, **AnyStr) -> object
+                return 42
+            """
+        self.check(a, b)
+
+    def test_add_varargs(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 1,
+              "signature": {
+                  "arg_types": ["int"],
+                  "return_type": "object"},
+              }])
+        a = """\
+            def nop(foo, *args):
+                return 42
+            """
+        b = """\
+            from typing import Any
+            def nop(foo, *args):
+                # type: (int, *Any) -> object
+                return 42
+            """
+        self.check(a, b)
+
+    def test_dont_add_varargs(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 1,
+              "signature": {
+                  "arg_types": ["int", "*int"],
+                  "return_type": "object"},
+              }])
+        a = """\
+            def nop(foo, *args):
+                return 42
+            """
+        b = """\
+            def nop(foo, *args):
+                # type: (int, *int) -> object
+                return 42
+            """
+        self.check(a, b)
+
+    def test_return_expr_not_none(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 1,
+              "signature": {
+                  "arg_types": [],
+                  "return_type": "None"},
+              }])
+        a = """\
+            def nop():
+                return 0
+            """
+        b = """\
+            from typing import Any
+            from typing import Optional
+            def nop():
+                # type: () -> Optional[Any]
+                return 0
+            """
+        self.check(a, b)
+
+    def test_return_expr_none(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 1,
+              "signature": {
+                  "arg_types": [],
+                  "return_type": "None"},
+              }])
+        a = """\
+            def nop():
+                return
+            """
+        b = """\
+            def nop():
+                # type: () -> None
+                return
+            """
+        self.check(a, b)
+
+    def test_generator_optional(self):
+        self.setTestData(
+            [{"func_name": "gen",
+              "path": "<string>",
+              "line": 1,
+              "signature": {
+                  "arg_types": [],
+                  "return_type": "Optional[int]"},
+              }])
+        a = """\
+            def gen():
+                yield 42
+            """
+        b = """\
+            from typing import Iterator
+            def gen():
+                # type: () -> Iterator[int]
+                yield 42
+            """
+        self.check(a, b)
+
+    def test_generator_plain(self):
+        self.setTestData(
+            [{"func_name": "gen",
+              "path": "<string>",
+              "line": 1,
+              "signature": {
+                  "arg_types": [],
+                  "return_type": "int"},
+              }])
+        a = """\
+            def gen():
+                yield 42
+            """
+        b = """\
+            from typing import Iterator
+            def gen():
+                # type: () -> Iterator[int]
+                yield 42
+            """
+        self.check(a, b)
+
+    def test_not_generator(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 1,
+              "signature": {
+                  "arg_types": [],
+                  "return_type": "int"},
+              }])
+        a = """\
+            def nop():
+                def gen():
+                    yield 42
+            """
+        b = """\
+            def nop():
+                # type: () -> int
+                def gen():
+                    yield 42
+            """
+        self.check(a, b)
+
+    def test_add_self(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 1,
+              "signature": {
+                  "arg_types": [],
+                  "return_type": "int"},
+              }])
+        a = """\
+            def nop(self):
+                pass
+            """
+        b = """\
+            from typing import Any
+            def nop(self):
+                # type: (Any) -> int
+                pass
+            """
+        self.check(a, b)
+
+    def test_dont_add_self(self):
+        self.setTestData(
+            [{"func_name": "C.nop",
+              "path": "<string>",
+              "line": 1,
+              "signature": {
+                  "arg_types": [],
+                  "return_type": "int"},
+              }])
+        a = """\
+            class C:
+                def nop(self):
+                    pass
+            """
+        b = """\
+            class C:
+                def nop(self):
+                    # type: () -> int
+                    pass
+            """
+        self.check(a, b)
+
+    def test_too_many_types(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 1,
+              "signature": {
+                  "arg_types": ["int"],
+                  "return_type": "int"},
+              }])
+        a = """\
+            def nop():
+                pass
+            """
+        self.warns(a, a, "source has 0 args, annotation has 1 -- skipping", unchanged=True)
+
+    def test_too_few_types(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 1,
+              "signature": {
+                  "arg_types": [],
+                  "return_type": "int"},
+              }])
+        a = """\
+            def nop(a):
+                pass
+            """
+        self.warns(a, a, "source has 1 args, annotation has 0 -- skipping", unchanged=True)
+
+    def test_line_number_drift(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 10,
+              "signature": {
+                  "arg_types": [],
+                  "return_type": "int"},
+              }])
+        a = """\
+            def nop(a):
+                pass
+            """
+        self.warns(a, a, "signature from line 10 too far away -- skipping", unchanged=True)
+
+    def test_classmethod(self):
+        # Class method names currently are returned without class name
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 3,
+              "signature": {
+                  "arg_types": ["int"],
+                  "return_type": "int"}
+              }])
+        a = """\
+            class C:
+                @classmethod
+                def nop(cls, a):
+                    return a
+            """
+        b = """\
+            class C:
+                @classmethod
+                def nop(cls, a):
+                    # type: (int) -> int
+                    return a
+            """
+        self.check(a, b)
+
+    def test_staticmethod(self):
+        # Static method names currently are returned without class name
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 3,
+              "signature": {
+                  "arg_types": ["int"],
+                  "return_type": "int"}
+              }])
+        a = """\
+            class C:
+                @staticmethod
+                def nop(a):
+                    return a
+            """
+        b = """\
+            class C:
+                @staticmethod
+                def nop(a):
+                    # type: (int) -> int
+                    return a
+            """
+        self.check(a, b)
+
+    def test_long_form(self):
+        self.maxDiff = None
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 1,
+              "signature": {
+                  "arg_types": ["int", "int", "int",
+                                "str", "str", "str",
+                                "Optional[bool]", "Union[int, str]", "*Any"],
+                  "return_type": "int"},
+              }])
+        a = """\
+            def nop(a, b, c,  # some comment
+                    d, e, f,  # multi-line
+                              # comment
+                    g=None, h=0, *args):
+                return 0
+            """
+        b = """\
+            from typing import Any
+            from typing import Optional
+            from typing import Union
+            def nop(a,  # type: int
+                    b,  # type: int
+                    c,  # type: int  # some comment
+                    d,  # type: str
+                    e,  # type: str
+                    f,  # type: str  # multi-line
+                              # comment
+                    g=None,  # type: Optional[bool]
+                    h=0,  # type: Union[int, str]
+                    *args  # type: Any
+                    ):
+                # type: (...) -> int
+                return 0
+            """
+        self.check(a, b)
+
+    def test_long_form_method(self):
+        self.maxDiff = None
+        self.setTestData(
+            [{"func_name": "C.nop",
+              "path": "<string>",
+              "line": 2,
+              "signature": {
+                  "arg_types": ["int", "int", "int",
+                                "str", "str", "str",
+                                "Optional[bool]", "Union[int, str]", "*Any"],
+                  "return_type": "int"},
+              }])
+        a = """\
+            class C:
+                def nop(self, a, b, c,  # some comment
+                              d, e, f,  # multi-line
+                                        # comment
+                              g=None, h=0, *args):
+                    return 0
+            """
+        b = """\
+            from typing import Any
+            from typing import Optional
+            from typing import Union
+            class C:
+                def nop(self,
+                        a,  # type: int
+                        b,  # type: int
+                        c,  # type: int  # some comment
+                        d,  # type: str
+                        e,  # type: str
+                        f,  # type: str  # multi-line
+                                        # comment
+                        g=None,  # type: Optional[bool]
+                        h=0,  # type: Union[int, str]
+                        *args  # type: Any
+                        ):
+                    # type: (...) -> int
+                    return 0
+            """
+        self.check(a, b)
+
+    def test_long_form_classmethod(self):
+        self.maxDiff = None
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 3,
+              "signature": {
+                  "arg_types": ["int", "int", "int",
+                                "str", "str", "str",
+                                "Optional[bool]", "Union[int, str]", "*Any"],
+                  "return_type": "int"},
+              }])
+        a = """\
+            class C:
+                @classmethod
+                def nop(cls, a, b, c,  # some comment
+                        d, e, f,
+                        g=None, h=0, *args):
+                    return 0
+            """
+        b = """\
+            from typing import Any
+            from typing import Optional
+            from typing import Union
+            class C:
+                @classmethod
+                def nop(cls,
+                        a,  # type: int
+                        b,  # type: int
+                        c,  # type: int  # some comment
+                        d,  # type: str
+                        e,  # type: str
+                        f,  # type: str
+                        g=None,  # type: Optional[bool]
+                        h=0,  # type: Union[int, str]
+                        *args  # type: Any
+                        ):
+                    # type: (...) -> int
+                    return 0
+            """
+        self.check(a, b)
+        # Do the same test for staticmethod
+        a = a.replace('classmethod', 'staticmethod')
+        b = b.replace('classmethod', 'staticmethod')
+        self.check(a, b)
+
+    def test_long_form_trailing_comma(self):
+        self.maxDiff = None
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 3,
+              "signature": {
+                  "arg_types": ["int", "int", "int",
+                                "str", "str", "str",
+                                "Optional[bool]", "Union[int, str]"],
+                  "return_type": "int"},
+              }])
+        a = """\
+            def nop(a, b, c,  # some comment
+                    d, e, f,
+                    g=None, h=0):
+                return 0
+            """
+        b = """\
+            from typing import Optional
+            from typing import Union
+            def nop(a,  # type: int
+                    b,  # type: int
+                    c,  # type: int  # some comment
+                    d,  # type: str
+                    e,  # type: str
+                    f,  # type: str
+                    g=None,  # type: Optional[bool]
+                    h=0,  # type: Union[int, str]
+                    ):
+                # type: (...) -> int
+                return 0
+            """
+        self.check(a, b)
+
+    def test_one_liner(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 1,
+              "signature": {
+                  "arg_types": ["int"],
+                  "return_type": "int"},
+              }])
+        a = """\
+            def nop(a):   return a
+            """
+        b = """\
+            def nop(a):
+                # type: (int) -> int
+                return a
+            """
+        self.check(a, b)

--- a/pyannotate_tools/fixes/tests/test_annotate_json_py3.py
+++ b/pyannotate_tools/fixes/tests/test_annotate_json_py3.py
@@ -16,6 +16,7 @@ class TestFixAnnotateJson(FixerTestCase):
         super(TestFixAnnotateJson, self).setUp(
             fix_list=["annotate_json"],
             fixer_pkg="pyannotate_tools",
+            options={'annotation_style' : 'py3'},
         )
         # See https://bugs.python.org/issue14243 for details
         self.tf = tempfile.NamedTemporaryFile(mode='w', delete=False)
@@ -53,8 +54,7 @@ class TestFixAnnotateJson(FixerTestCase):
             from typing import Any
             class Foo: pass
             class Bar: pass
-            def nop(foo, bar):
-                # type: (Foo, Bar) -> Any
+            def nop(foo: Foo, bar: Bar) -> Any:
                 return 42
             """
         self.check(a, b)
@@ -78,8 +78,7 @@ class TestFixAnnotateJson(FixerTestCase):
             from typing import Any
             class Foo: pass
             class Bar: pass
-            def nop(foo, *, bar):
-                # type: (Foo, Bar) -> Any
+            def nop(foo: Foo, *, bar: Bar) -> Any:
                 return 42
             """
         self.check(a, b)
@@ -102,8 +101,7 @@ class TestFixAnnotateJson(FixerTestCase):
             from typing import AnyStr
             from typing import Callable
             from typing import List
-            def nop(foo, bar):
-                # type: (List[AnyStr], Callable[[], int]) -> object
+            def nop(foo: List[AnyStr], bar: Callable[[], int]) -> object:
                 return 42
             """
         self.check(a, b)
@@ -125,8 +123,7 @@ class TestFixAnnotateJson(FixerTestCase):
         b = """\
             from mod2 import OtherClass
             from mod3 import AnotherClass
-            def nop(foo, bar):
-                # type: (MyClass, OtherClass) -> AnotherClass
+            def nop(foo: MyClass, bar: OtherClass) -> AnotherClass:
                 return AnotherClass()
             class MyClass: pass
             """
@@ -147,8 +144,7 @@ class TestFixAnnotateJson(FixerTestCase):
             """
         b = """\
             from typing import Any
-            def nop(foo, **kwds):
-                # type: (int, **Any) -> object
+            def nop(foo: int, **kwds: Any) -> object:
                 return 42
             """
         self.check(a, b)
@@ -168,8 +164,7 @@ class TestFixAnnotateJson(FixerTestCase):
             """
         b = """\
             from typing import AnyStr
-            def nop(foo, **kwds):
-                # type: (int, **AnyStr) -> object
+            def nop(foo: int, **kwds: AnyStr) -> object:
                 return 42
             """
         self.check(a, b)
@@ -189,8 +184,7 @@ class TestFixAnnotateJson(FixerTestCase):
             """
         b = """\
             from typing import Any
-            def nop(foo, *args):
-                # type: (int, *Any) -> object
+            def nop(foo: int, *args: Any) -> object:
                 return 42
             """
         self.check(a, b)
@@ -209,8 +203,7 @@ class TestFixAnnotateJson(FixerTestCase):
                 return 42
             """
         b = """\
-            def nop(foo, *args):
-                # type: (int, *int) -> object
+            def nop(foo: int, *args: int) -> object:
                 return 42
             """
         self.check(a, b)
@@ -231,8 +224,7 @@ class TestFixAnnotateJson(FixerTestCase):
         b = """\
             from typing import Any
             from typing import Optional
-            def nop():
-                # type: () -> Optional[Any]
+            def nop() -> Optional[Any]:
                 return 0
             """
         self.check(a, b)
@@ -251,8 +243,7 @@ class TestFixAnnotateJson(FixerTestCase):
                 return
             """
         b = """\
-            def nop():
-                # type: () -> None
+            def nop() -> None:
                 return
             """
         self.check(a, b)
@@ -272,8 +263,7 @@ class TestFixAnnotateJson(FixerTestCase):
             """
         b = """\
             from typing import Iterator
-            def gen():
-                # type: () -> Iterator[int]
+            def gen() -> Iterator[int]:
                 yield 42
             """
         self.check(a, b)
@@ -293,8 +283,7 @@ class TestFixAnnotateJson(FixerTestCase):
             """
         b = """\
             from typing import Iterator
-            def gen():
-                # type: () -> Iterator[int]
+            def gen() -> Iterator[int]:
                 yield 42
             """
         self.check(a, b)
@@ -314,8 +303,7 @@ class TestFixAnnotateJson(FixerTestCase):
                     yield 42
             """
         b = """\
-            def nop():
-                # type: () -> int
+            def nop() -> int:
                 def gen():
                     yield 42
             """
@@ -336,8 +324,7 @@ class TestFixAnnotateJson(FixerTestCase):
             """
         b = """\
             from typing import Any
-            def nop(self):
-                # type: (Any) -> int
+            def nop(self: Any) -> int:
                 pass
             """
         self.check(a, b)
@@ -358,8 +345,7 @@ class TestFixAnnotateJson(FixerTestCase):
             """
         b = """\
             class C:
-                def nop(self):
-                    # type: () -> int
+                def nop(self) -> int:
                     pass
             """
         self.check(a, b)
@@ -428,8 +414,7 @@ class TestFixAnnotateJson(FixerTestCase):
         b = """\
             class C:
                 @classmethod
-                def nop(cls, a):
-                    # type: (int) -> int
+                def nop(cls, a: int) -> int:
                     return a
             """
         self.check(a, b)
@@ -453,8 +438,7 @@ class TestFixAnnotateJson(FixerTestCase):
         b = """\
             class C:
                 @staticmethod
-                def nop(a):
-                    # type: (int) -> int
+                def nop(a: int) -> int:
                     return a
             """
         self.check(a, b)
@@ -482,18 +466,10 @@ class TestFixAnnotateJson(FixerTestCase):
             from typing import Any
             from typing import Optional
             from typing import Union
-            def nop(a,  # type: int
-                    b,  # type: int
-                    c,  # type: int  # some comment
-                    d,  # type: str
-                    e,  # type: str
-                    f,  # type: str  # multi-line
+            def nop(a: int, b: int, c: int,  # some comment
+                    d: str, e: str, f: str,  # multi-line
                               # comment
-                    g=None,  # type: Optional[bool]
-                    h=0,  # type: Union[int, str]
-                    *args  # type: Any
-                    ):
-                # type: (...) -> int
+                    g: Optional[bool] = None, h: Union[int, str] = 0, *args: Any) -> int:
                 return 0
             """
         self.check(a, b)
@@ -523,19 +499,10 @@ class TestFixAnnotateJson(FixerTestCase):
             from typing import Optional
             from typing import Union
             class C:
-                def nop(self,
-                        a,  # type: int
-                        b,  # type: int
-                        c,  # type: int  # some comment
-                        d,  # type: str
-                        e,  # type: str
-                        f,  # type: str  # multi-line
+                def nop(self, a: int, b: int, c: int,  # some comment
+                              d: str, e: str, f: str,  # multi-line
                                         # comment
-                        g=None,  # type: Optional[bool]
-                        h=0,  # type: Union[int, str]
-                        *args  # type: Any
-                        ):
-                    # type: (...) -> int
+                              g: Optional[bool] = None, h: Union[int, str] = 0, *args: Any) -> int:
                     return 0
             """
         self.check(a, b)
@@ -566,18 +533,9 @@ class TestFixAnnotateJson(FixerTestCase):
             from typing import Union
             class C:
                 @classmethod
-                def nop(cls,
-                        a,  # type: int
-                        b,  # type: int
-                        c,  # type: int  # some comment
-                        d,  # type: str
-                        e,  # type: str
-                        f,  # type: str
-                        g=None,  # type: Optional[bool]
-                        h=0,  # type: Union[int, str]
-                        *args  # type: Any
-                        ):
-                    # type: (...) -> int
+                def nop(cls, a: int, b: int, c: int,  # some comment
+                        d: str, e: str, f: str,
+                        g: Optional[bool] = None, h: Union[int, str] = 0, *args: Any) -> int:
                     return 0
             """
         self.check(a, b)
@@ -607,16 +565,9 @@ class TestFixAnnotateJson(FixerTestCase):
         b = """\
             from typing import Optional
             from typing import Union
-            def nop(a,  # type: int
-                    b,  # type: int
-                    c,  # type: int  # some comment
-                    d,  # type: str
-                    e,  # type: str
-                    f,  # type: str
-                    g=None,  # type: Optional[bool]
-                    h=0,  # type: Union[int, str]
-                    ):
-                # type: (...) -> int
+            def nop(a: int, b: int, c: int,  # some comment
+                    d: str, e: str, f: str,
+                    g: Optional[bool] = None, h: Union[int, str] = 0) -> int:
                 return 0
             """
         self.check(a, b)
@@ -634,8 +585,6 @@ class TestFixAnnotateJson(FixerTestCase):
             def nop(a):   return a
             """
         b = """\
-            def nop(a):
-                # type: (int) -> int
-                return a
+            def nop(a: int) -> int:   return a
             """
         self.check(a, b)

--- a/pyannotate_tools/fixes/tests/test_annotate_py2.py
+++ b/pyannotate_tools/fixes/tests/test_annotate_py2.py
@@ -13,6 +13,7 @@ class TestFixAnnotate(FixerTestCase):
         super(TestFixAnnotate, self).setUp(
             fix_list=["annotate"],
             fixer_pkg="pyannotate_tools",
+            options={'annotation_style' : 'py2'},
         )
 
     def test_no_arg(self):

--- a/pyannotate_tools/fixes/tests/test_annotate_py3.py
+++ b/pyannotate_tools/fixes/tests/test_annotate_py3.py
@@ -1,0 +1,617 @@
+# flake8: noqa
+# Our flake extension misfires on type comments in strings below.
+
+from lib2to3.tests.test_fixers import FixerTestCase
+import unittest
+
+# deadcode: fix_annotate is used as part of the fixer_pkg for this test
+from pyannotate_tools.fixes import fix_annotate
+
+
+class TestFixAnnotate3(FixerTestCase):
+
+    def setUp(self):
+        super(TestFixAnnotate3, self).setUp(
+            fix_list=["annotate"],
+            fixer_pkg="pyannotate_tools",
+            options={'annotation_style' : 'py3'}
+        )
+
+    def test_no_arg_1(self) :
+        a = """\
+            def nop():
+                return 42
+            """
+        b = """\
+            from typing import Any
+            def nop() -> Any:
+                return 42
+            """
+        self.check(a, b)
+
+    def test_no_arg_2(self) :
+        a = """\
+            def nop(): return 42
+            """
+        b = """\
+            from typing import Any
+            def nop() -> Any: return 42
+            """
+        self.check(a, b)
+
+    def test_no_arg_3(self) :
+        a = """\
+            def nop(
+                    ): 
+                return 42
+            """
+        b = """\
+            from typing import Any
+            def nop(
+                    ) -> Any: 
+                return 42
+            """
+        self.check(a, b)
+
+    def test_no_arg_4(self) :
+        a = """\
+            def nop(
+                    )   \
+                    : 
+                return 42
+            """
+        b = """\
+            from typing import Any
+            def nop(
+                    ) -> Any   \
+                    : 
+                return 42
+            """
+        self.check(a, b)
+
+    def test_no_arg_5(self) :
+        a = """\
+            def nop(    # blah
+                    ):  # blah
+                return 42 # blah
+            """
+        b = """\
+            from typing import Any
+            def nop(    # blah
+                    ) -> Any:  # blah
+                return 42 # blah
+            """
+        self.check(a, b)
+
+    def test_no_arg_6(self) :
+        a = """\
+            def nop(    # blah
+                    )   \
+                    :   # blah
+                return 42 # blah
+            """
+        b = """\
+            from typing import Any
+            def nop(    # blah
+                    ) -> Any   \
+                    :   # blah
+                return 42 # blah
+            """
+        self.check(a, b)
+
+    def test_one_arg_1(self):
+        a = """\
+            def incr(arg):
+                return arg+1
+            """
+        b = """\
+            from typing import Any
+            def incr(arg: Any) -> Any:
+                return arg+1
+            """
+        self.check(a, b)
+
+
+    def test_one_arg_2(self):
+        a = """\
+            def incr(arg=0):
+                return arg+1
+            """
+        b = """\
+            from typing import Any
+            def incr(arg: int = 0) -> Any:
+                return arg+1
+            """
+        self.check(a, b)
+
+    def test_one_arg_3(self):
+        a = """\
+            def incr( arg=0 ):
+                return arg+1
+            """
+        b = """\
+            from typing import Any
+            def incr( arg: int = 0 ) -> Any:
+                return arg+1
+            """
+        self.check(a, b)
+
+    def test_one_arg_4(self):
+        a = """\
+            def incr( arg = 0 ):
+                return arg+1
+            """
+        b = """\
+            from typing import Any
+            def incr( arg: int = 0 ) -> Any:
+                return arg+1
+            """
+        self.check(a, b)
+
+    def test_two_args_1(self):
+        a = """\
+            def add(arg1, arg2):
+                return arg1+arg2
+            """
+        b = """\
+            from typing import Any
+            def add(arg1: Any, arg2: Any) -> Any:
+                return arg1+arg2
+            """
+        self.check(a, b)
+
+    def test_two_args_2(self):
+        a = """\
+            def add(arg1=0, arg2=0.1):
+                return arg1+arg2
+            """
+        b = """\
+            from typing import Any
+            def add(arg1: int = 0, arg2: float = 0.1) -> Any:
+                return arg1+arg2
+            """
+        self.check(a, b)
+
+    def test_two_args_3(self):
+        a = """\
+            def add(arg1, arg2=0.1):
+                return arg1+arg2
+            """
+        b = """\
+            from typing import Any
+            def add(arg1: Any, arg2: float = 0.1) -> Any:
+                return arg1+arg2
+            """
+
+    def test_two_args_4(self):
+        a = """\
+            def add(arg1, arg2 = 0.1):
+                return arg1+arg2
+            """
+        b = """\
+            from typing import Any
+            def add(arg1: Any, arg2: float = 0.1) -> Any:
+                return arg1+arg2
+            """
+        self.check(a, b)
+        self.check(a, b)
+
+    def test_defaults_1(self):
+        a = """\
+            def foo(iarg=0, farg=0.0, sarg='', uarg=u'', barg=False):
+                return 42
+            """
+        b = """\
+            from typing import Any
+            def foo(iarg: int = 0, farg: float = 0.0, sarg: str = '', uarg: unicode = u'', barg: bool = False) -> Any:
+                return 42
+            """
+        self.check(a, b)
+
+    def test_defaults_2(self):
+        a = """\
+            def foo(iarg=0, farg=0.0, sarg='', uarg=u'', barg=False, targ=(1,2,3)):
+                return 42
+            """
+        b = """\
+            from typing import Any
+            def foo(iarg: int = 0, farg: float = 0.0, sarg: str = '', uarg: unicode = u'', barg: bool = False, targ: Any = (1,2,3)) -> Any:
+                return 42
+            """
+        self.check(a, b)
+
+    def test_defaults_3(self):
+        a = """\
+            def foo(iarg=0, farg, sarg='', uarg, barg=False, targ=(1,2,3)):
+                return 42
+            """
+        b = """\
+            from typing import Any
+            def foo(iarg: int = 0, farg: Any, sarg: str = '', uarg: Any, barg: bool = False, targ: Any = (1,2,3)) -> Any:
+                return 42
+            """
+        self.check(a, b)
+
+    def test_staticmethod(self):
+        a = """\
+            class C:
+                @staticmethod
+                def incr(self):
+                    return 42
+            """
+        b = """\
+            from typing import Any
+            class C:
+                @staticmethod
+                def incr(self: Any) -> Any:
+                    return 42
+            """
+        self.check(a, b)
+
+    def test_classmethod(self):
+        a = """\
+            class C:
+                @classmethod
+                def incr(cls, arg):
+                    return 42
+            """
+        b = """\
+            from typing import Any
+            class C:
+                @classmethod
+                def incr(cls, arg: Any) -> Any:
+                    return 42
+            """
+        self.check(a, b)
+
+    def test_instancemethod(self):
+        a = """\
+            class C:
+                def incr(self, arg):
+                    return 42
+            """
+        b = """\
+            from typing import Any
+            class C:
+                def incr(self, arg: Any) -> Any:
+                    return 42
+            """
+        self.check(a, b)
+
+    def test_fake_self(self):
+        a = """\
+            def incr(self, arg):
+                return 42
+            """
+        b = """\
+            from typing import Any
+            def incr(self: Any, arg: Any) -> Any:
+                return 42
+            """
+        self.check(a, b)
+
+    def test_nested_fake_self(self):
+        a = """\
+            class C:
+                def outer(self):
+                    def inner(self, arg):
+                        return 42
+            """
+        b = """\
+            from typing import Any
+            class C:
+                def outer(self) -> None:
+                    def inner(self: Any, arg: Any) -> Any:
+                        return 42
+            """
+        self.check(a, b)
+
+    def test_multiple_decorators(self):
+        a = """\
+            class C:
+                @contextmanager
+                @classmethod
+                @wrapped('func')
+                def incr(cls, arg):
+                    return 42
+            """
+        b = """\
+            from typing import Any
+            class C:
+                @contextmanager
+                @classmethod
+                @wrapped('func')
+                def incr(cls, arg: Any) -> Any:
+                    return 42
+            """
+        self.check(a, b)
+
+    def test_stars_1(self):
+        a = """\
+            def stuff(*a):
+                return 4, 2
+            """
+        b = """\
+            from typing import Any
+            def stuff(*a: Any) -> Any:
+                return 4, 2
+            """
+        self.check(a, b)
+
+    def test_stars_2(self):
+        a = """\
+            def stuff(a, *b):
+                return 4, 2
+            """
+        b = """\
+            from typing import Any
+            def stuff(a: Any, *b: Any) -> Any:
+                return 4, 2
+            """
+        self.check(a, b)
+
+        
+    def test_keywords_1(self):
+        a = """\
+            def stuff(**kw):
+                return 4, 2
+            """
+        b = """\
+            from typing import Any
+            def stuff(**kw: Any) -> Any:
+                return 4, 2
+            """
+        self.check(a, b)
+
+    def test_keywords_2(self):
+        a = """\
+            def stuff(a, **kw):
+                return 4, 2
+            """
+        b = """\
+            from typing import Any
+            def stuff(a: Any, **kw: Any) -> Any:
+                return 4, 2
+            """
+        self.check(a, b)
+
+    def test_keywords_3(self):
+        a = """\
+            def stuff(a, *b, **kw):
+                return 4, 2
+            """
+        b = """\
+            from typing import Any
+            def stuff(a: Any, *b: Any, **kw: Any) -> Any:
+                return 4, 2
+            """
+        self.check(a, b)
+
+    def test_keywords_4(self):
+        a = """\
+            def stuff(*b, **kw):
+                return 4, 2
+            """
+        b = """\
+            from typing import Any
+            def stuff(*b: Any, **kw: Any) -> Any:
+                return 4, 2
+            """
+        self.check(a, b)
+
+    def test_no_return_expr(self):
+        a = """\
+            def proc1(arg):
+                return
+            def proc2(arg):
+                pass
+            """
+        b = """\
+            from typing import Any
+            def proc1(arg: Any) -> None:
+                return
+            def proc2(arg: Any) -> None:
+                pass
+            """
+        self.check(a, b)
+
+    def test_nested_return_expr(self):
+        # The 'return expr' in inner() shouldn't affect the return type of outer().
+        a = """\
+            def outer(arg):
+                def inner():
+                    return 42
+                return
+            """
+        b = """\
+            from typing import Any
+            def outer(arg: Any) -> None:
+                def inner() -> Any:
+                    return 42
+                return
+            """
+        self.check(a, b)
+
+    def test_nested_class_return_expr(self):
+        # The 'return expr' in class Inner shouldn't affect the return type of outer().
+        a = """\
+            def outer(arg):
+                class Inner:
+                    return 42
+                return
+            """
+        b = """\
+            from typing import Any
+            def outer(arg: Any) -> None:
+                class Inner:
+                    return 42
+                return
+            """
+        self.check(a, b)
+
+    def test_add_import(self):
+        a = """\
+            import typing
+            from typing import Callable
+
+            def incr(arg):
+                return 42
+            """
+        b = """\
+            import typing
+            from typing import Callable
+            from typing import Any
+
+            def incr(arg: Any) -> Any:
+                return 42
+            """
+        self.check(a, b)
+
+    def test_dont_add_import(self):
+        a = """\
+            def nop(arg=0):
+                return
+            """
+        b = """\
+            def nop(arg: int = 0) -> None:
+                return
+            """
+        self.check(a, b)
+
+    def test_long_form(self):
+        self.maxDiff = None
+        a = """\
+            def nop(arg0, arg1, arg2, arg3, arg4,
+                    arg5, arg6, arg7, arg8=0, arg9='',
+                    *args, **kwds):
+                return
+            """
+        b = """\
+            from typing import Any
+            def nop(arg0: Any, arg1: Any, arg2: Any, arg3: Any, arg4: Any,
+                    arg5: Any, arg6: Any, arg7: Any, arg8: int = 0, arg9: str = '',
+                    *args: Any, **kwds: Any) -> None:
+                return
+            """
+        self.check(a, b)
+
+    def test_long_form_trailing_comma(self):
+        self.maxDiff = None
+        a = """\
+            def nop(arg0, arg1, arg2, arg3, arg4, arg5, arg6,
+                    arg7=None, arg8=0, arg9='', arg10=False,):
+                return
+            """
+        b = """\
+            from typing import Any
+            def nop(arg0: Any, arg1: Any, arg2: Any, arg3: Any, arg4: Any, arg5: Any, arg6: Any,
+                    arg7: Any = None, arg8: int = 0, arg9: str = '', arg10: bool = False,) -> None:
+                return
+            """
+        self.check(a, b)
+
+    def test_one_liner(self):
+        a = """\
+            class C:
+                def nop(self, a): a = a; return a
+                # Something
+            # More
+            pass
+            """
+        b = """\
+            from typing import Any
+            class C:
+                def nop(self, a: Any) -> Any: a = a; return a
+                # Something
+            # More
+            pass
+            """
+        self.check(a, b)
+
+    def test_idempotency_long_1arg(self):
+        a = """\
+            def nop(a: int
+                    ):
+                pass
+            """
+        self.unchanged(a)
+
+    def test_idempotency_long_1arg_comma(self):
+        a = """\
+            def nop(a: int,
+                    ):
+                pass
+            """
+        self.unchanged(a)
+
+    def test_idempotency_long_2args_first(self):
+        a = """\
+            def nop(a: int,
+                    b):
+                pass
+            """
+        self.unchanged(a)
+
+    def test_idempotency_long_2args_last(self):
+        a = """\
+            def nop(a,
+                    b: int
+                    ):
+                pass
+            """
+        self.unchanged(a)
+
+    def test_idempotency_long_varargs(self):
+        a = """\
+            def nop(*a: int
+                    ):
+                pass
+            """
+        self.unchanged(a)
+
+    def test_idempotency_long_kwargs(self):
+        a = """\
+            def nop(**a: int
+                    ):
+                pass
+            """
+        self.unchanged(a)
+
+
+    def test_idempotency_arg0_ret_value(self):
+        a = """\
+            def nop() -> int:
+                pass
+            """
+        self.unchanged(a)
+
+    def test_idempotency_arg1_ret_value(self):
+        a = """\
+            def nop(a) -> int:
+                pass
+            """
+        self.unchanged(a)
+
+    def test_idempotency_arg1_default_1(self):
+        a = """\
+            def nop(a: int=0):
+                pass
+            """
+        self.unchanged(a)
+
+    def test_idempotency_arg1_default_2(self):
+        a = """\
+            def nop(a: List[int]=[]):
+                pass
+            """
+        self.unchanged(a)
+
+    def test_idempotency_arg1_default_3(self):
+        a = """\
+            def nop(a: List[int]=[1,2,3]):
+                pass
+            """
+        self.unchanged(a)
+
+
+


### PR DESCRIPTION

Implementation for  #4 is done.

All tests are ported and pass successfully.

A few remarks on the implementation : 
- command-line options are the same as mypy : -2, --py2, -3, --py3, --python-version
- the code will not annotate functions with an existing py2 or py3 annotation
- I ignored the concept of long form for python 3 annotations. Function with many arguments are still annotated inline.
- test_annotate.py and test_annotate_json.py have been renamed with a _py2 and _py3 suffix depending on what they are testing.

Looking forward for your feedback.

