### PR TITLE
Fix Ellipsis bug

### DIFF
--- a/pyannotate_tools/fixes/fix_annotate_json.py
+++ b/pyannotate_tools/fixes/fix_annotate_json.py
@@ -279,6 +279,8 @@ class FixAnnotateJson(FixAnnotate):
         # Replace `pkg.mod.SomeClass` with `SomeClass`
         # and remember to import it.
         word = match.group()
+        if word == '...':
+            return word
         if '.' not in word:
             # Assume it's either builtin or from `typing`
             if word in typing_all:

--- a/pyannotate_tools/fixes/tests/test_annotate_json_py2.py
+++ b/pyannotate_tools/fixes/tests/test_annotate_json_py2.py
@@ -640,3 +640,23 @@ class TestFixAnnotateJson(FixerTestCase):
                 return a
             """
         self.check(a, b)
+
+    def test_variadic(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 1,
+              "signature": {
+                  "arg_types": ["Tuple[int, ...]"],
+                  "return_type": "int"},
+              }])
+        a = """\
+            def nop(a):   return 0
+            """
+        b = """\
+            from typing import Tuple
+            def nop(a):
+                # type: (Tuple[int, ...]) -> int
+                return 0
+            """
+        self.check(a, b)

--- a/pyannotate_tools/fixes/tests/test_annotate_json_py3.py
+++ b/pyannotate_tools/fixes/tests/test_annotate_json_py3.py
@@ -588,3 +588,21 @@ class TestFixAnnotateJson(FixerTestCase):
             def nop(a: int) -> int:   return a
             """
         self.check(a, b)
+
+    def test_variadic(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 1,
+              "signature": {
+                  "arg_types": ["Tuple[int, ...]"],
+                  "return_type": "int"},
+              }])
+        a = """\
+            def nop(a):   return 0
+            """
+        b = """\
+            from typing import Tuple
+            def nop(a: Tuple[int, ...]) -> int:   return 0
+            """
+        self.check(a, b)


### PR DESCRIPTION
When trying pyannotate, I found that `...` is not handled properly.

A very simple case would be like:(for simplicity I just copy/paste the test case code)
```python
def test_variadic(self):
    self.setTestData(
        [{"func_name": "nop",
          "path": "<string>",
          "line": 1,
          "signature": {
              "arg_types": ["Tuple[int, ...]"],
              "return_type": "int"},
          }])
    a = """\
        def nop(a):   return 0
        """
    b = """\
        from typing import Tuple
        def nop(a):
            # type: (Tuple[int, ...]) -> int
            return 0
        """
    self.check(a, b)
```
This would cause the following error
```bash
E   AssertionError: 'from typing import Tuple\ndef nop(a):\n    # t[45 chars]\n\n' != 'from .. import \nfrom typing import Tuple\ndef[59 chars]\n\n'
E   + from .. import
E     from typing import Tuple
E     def nop(a):
E   -     # type: (Tuple[int, ...]) -> int
E   ?                         ---
E   +     # type: (Tuple[int, ]) -> int
E         return 0
```

The problem lies in `type_updater` function, where it's treating words with `.` as `pkg.mod.SomeClass`, however `...` is a special case.

The fix is also easy. If the word is `...`, we don't need to import anything and should just return `...` itself, so that it is properly added to type annotations.