### PR TITLE
Issue #75 Mismatch of json files to cwd, bugfix works for me

### DIFF
--- a/pyannotate_tools/fixes/fix_annotate_json.py
+++ b/pyannotate_tools/fixes/fix_annotate_json.py
@@ -48,7 +48,11 @@ def crawl_up(arg):
     """
     dir, mod = os.path.split(arg)
     mod = strip_py(mod) or mod
+    cwd = os.getcwd()
     while dir and get_init_file(dir):
+        if cwd == dir:
+            # we are somewhere in the tree and our json file is here
+            break
         dir, base = os.path.split(dir)
         if not base:
             break


### PR DESCRIPTION
Hello, I love this tool and thank you for creating it.
I have encountered the issue mentioned in #75  The issue is that it finds the directory above my cwd which does not contain an `__init__.py` file. I have changed it to break at the cwd so that it will not go deeper.

So top dir is the first path without an init in there. That is basically the parent dir of my project. I am running the tests driver that generates the json not from the top dir but from one directory underneath it.

I do so because the topdir contains a src/ directory that has been created by `pip install -e` and pytest finds conftests from other projects there.

The checks on file path are brittle and could also be adjusted to accommodate for slight differences in the path. 
https://github.com/dropbox/pyannotate/blob/de6ccf8d3f384961048418d1e203bcc5b33465c7/pyannotate_tools/fixes/fix_annotate_json.py#L207

I hope this patch helps out anyone who might be having issues.