### PR TITLE
Fix current module calculation in fixer

### DIFF
--- a/pyannotate_tools/fixes/fix_annotate_json.py
+++ b/pyannotate_tools/fixes/fix_annotate_json.py
@@ -164,16 +164,7 @@ class FixAnnotateJson(FixAnnotate):
         self.needed_imports = None
 
     def current_module(self):
-        # TODO: cache this?
-        filename = self.filename
-        if filename.endswith('.py'):
-            filename = filename[:-3]
-        parts = filename.split(os.sep)
-        if parts[-1] == '__init__':
-            del parts[-1]
-        if parts[0] == '.':
-            del parts[0]
-        return '.'.join(parts)
+        return self._current_module
 
     def make_annotation(self, node, results):
         name = results['name']
@@ -190,7 +181,7 @@ class FixAnnotateJson(FixAnnotate):
     @classmethod
     def init_stub_json_from_data(cls, data, filename):
         cls.stub_json = data
-        cls.top_dir, _ = crawl_up(os.path.abspath(filename))
+        cls.top_dir, cls._current_module = crawl_up(os.path.abspath(filename))
 
     def init_stub_json(self):
         with open(self.__class__.stub_json_file) as f:

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -30,7 +30,7 @@ if __name__ == '__main__':
 """
 
 class_example = """
-class A: pass
+class A(object): pass
 
 def f(x):
     return x

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import shutil
 
 
 example = """
@@ -28,6 +29,19 @@ if __name__ == '__main__':
     collect_types.dump_stats('type_info.json')
 """
 
+class_example = """
+class A:
+   # This is a method because when I tried this test with a function
+   # the runtime stuff didn't get it???
+   def g(self, x):
+       return x
+
+def main():
+    print(A())
+    print(A())
+    A().g(A())
+"""
+
 
 class IntegrationTest(unittest.TestCase):
 
@@ -39,6 +53,7 @@ class IntegrationTest(unittest.TestCase):
 
     def tearDown(self):
         os.chdir(self.savedir)
+        shutil.rmtree(self.tempdir)
 
     def test_simple(self):
         with open('gcd.py', 'w') as f:
@@ -104,3 +119,22 @@ class IntegrationTest(unittest.TestCase):
         lines = output.splitlines()
         assert b'+    # type: () -> None' in lines
         assert b'+    # type: (int, int) -> int' in lines
+
+    def test_subdir_w_class(self):
+        os.makedirs('foo')
+        with open('foo/bar.py', 'w') as f:
+            f.write(class_example)
+        with open('driver.py', 'w') as f:
+            f.write('import sys\n')
+            f.write('sys.path.insert(0, "foo")\n')
+            f.write('from bar import main\n')
+            f.write(driver)
+        subprocess.check_call([sys.executable, 'driver.py'])
+        output = subprocess.check_output([sys.executable, '-m', 'pyannotate_tools.annotations',
+                                          # Construct platform-correct pathname:
+                                          os.path.join('foo', 'bar.py')])
+        lines = output.splitlines()
+        print(b'\n'.join(lines).decode())
+        assert b'+    # type: () -> None' in lines
+        assert b'+       # type: (A) -> A' in lines
+        assert not any(line.startswith(b'+') and b'import' in line for line in lines)

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -30,16 +30,14 @@ if __name__ == '__main__':
 """
 
 class_example = """
-class A:
-   # This is a method because when I tried this test with a function
-   # the runtime stuff didn't get it???
-   def g(self, x):
-       return x
+class A: pass
+
+def f(x):
+    return x
 
 def main():
-    print(A())
-    print(A())
-    A().g(A())
+    f(A())
+    f(A())
 """
 
 
@@ -136,5 +134,5 @@ class IntegrationTest(unittest.TestCase):
         lines = output.splitlines()
         print(b'\n'.join(lines).decode())
         assert b'+    # type: () -> None' in lines
-        assert b'+       # type: (A) -> A' in lines
+        assert b'+    # type: (A) -> A' in lines
         assert not any(line.startswith(b'+') and b'import' in line for line in lines)


### PR DESCRIPTION
When fixing a file named foo/bar/baz.py where bar does not contain an
__init__.py, we currently calculate that the module is named
foo.bar.baz. Then, if something like baz.Spam is included in an
annotation, we will erroneously insert an import of baz.
Fix this by calculating module name based on the directory crawl
(which we already do to find the module root).

This is wrong if the file is supposed to be in a namespace packages, I
guess, but I'm pretty sure the existing code is also wrong in that
case but in different ways.

The test framework doesn't really seem set up to test this kind of
thing, so there isn't a test, but I tested manually.