### PR TITLE
Correctly fix files in subdirectories without __init__.py files

### DIFF
--- a/pyannotate_tools/fixes/fix_annotate_json.py
+++ b/pyannotate_tools/fixes/fix_annotate_json.py
@@ -202,10 +202,12 @@ class FixAnnotateJson(FixAnnotate):
             self.init_stub_json()
         data = self.__class__.stub_json
         # We are using relative paths in the JSON.
-        items = [it for it in data
-                 if it['func_name'] == funcname and
-                    (os.path.join(self.__class__.top_dir, it['path']) ==
-                     os.path.abspath(self.filename))]
+        items = [
+            it for it in data
+            if it['func_name'] == funcname and
+               (it['path'] == self.filename or
+                os.path.join(self.__class__.top_dir, it['path']) == os.path.abspath(self.filename))
+        ]
         if len(items) > 1:
             # this can happen, because of
             # 1) nested functions

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -88,7 +88,6 @@ class IntegrationTest(unittest.TestCase):
         assert b'+    # type: () -> None' in lines
         assert b'+    # type: (int, int) -> int' in lines
 
-    @unittest.skip("Doesn't work yet")
     def test_subdir(self):
         os.makedirs('foo')
         with open('foo/gcd.py', 'w') as f:

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -98,7 +98,9 @@ class IntegrationTest(unittest.TestCase):
             f.write('from gcd import main\n')
             f.write(driver)
         subprocess.check_call([sys.executable, 'driver.py'])
-        output = subprocess.check_output([sys.executable, '-m', 'pyannotate_tools.annotations', 'foo/gcd.py'])
+        output = subprocess.check_output([sys.executable, '-m', 'pyannotate_tools.annotations',
+                                          # Construct platform-correct pathname:
+                                          os.path.join('foo', 'gcd.py')])
         lines = output.splitlines()
         assert b'+    # type: () -> None' in lines
         assert b'+    # type: (int, int) -> int' in lines


### PR DESCRIPTION
As long as that subdirectory is underneath the current directory.

Fixes #75.