### PR TITLE
Support handling nested classes

### DIFF
--- a/pyannotate_runtime/collect_types.py
+++ b/pyannotate_runtime/collect_types.py
@@ -54,7 +54,7 @@ from typing import (
 )
 from contextlib import contextmanager
 
-MYPY=False  
+MYPY=False
 if MYPY:
     # MYPY is True when mypy is running
     # 'Type' is only required for running mypy, not for running pyannotate
@@ -430,7 +430,8 @@ def name_from_type(type_):
                 # Also ignore '<uknown>' modules so pyannotate can parse these types
                 return type_.__name__
             else:
-                return '%s.%s' % (module, type_.__name__)
+                name = getattr(type_, '__qualname__', None) or type_.__name__
+                return '%s.%s' % (module, name)
         else:
             return 'None'
 

--- a/pyannotate_runtime/collect_types.py
+++ b/pyannotate_runtime/collect_types.py
@@ -431,7 +431,8 @@ def name_from_type(type_):
                 return type_.__name__
             else:
                 name = getattr(type_, '__qualname__', None) or type_.__name__
-                return '%s:%s' % (module, name)
+                delim = '.' if '.' not in name else ':'
+                return '%s%s%s' % (module, delim, name)
         else:
             return 'None'
 

--- a/pyannotate_runtime/collect_types.py
+++ b/pyannotate_runtime/collect_types.py
@@ -431,7 +431,7 @@ def name_from_type(type_):
                 return type_.__name__
             else:
                 name = getattr(type_, '__qualname__', None) or type_.__name__
-                return '%s.%s' % (module, name)
+                return '%s:%s' % (module, name)
         else:
             return 'None'
 

--- a/pyannotate_runtime/tests/test_collect_types.py
+++ b/pyannotate_runtime/tests/test_collect_types.py
@@ -325,17 +325,17 @@ class TestCollectTypes(TestBaseClass):
         # print_int,
         self.assert_type_comments(
             'WorkerClass.__init__',
-            ['(int, pyannotate_runtime.tests.test_collect_types:FooObject) -> None'])
+            ['(int, pyannotate_runtime.tests.test_collect_types.FooObject) -> None'])
         self.assert_type_comments(
             'do_work_clsmthd',
-            ['(int, pyannotate_runtime.tests.test_collect_types:FooNamedTuple) -> EOFError'])
+            ['(int, pyannotate_runtime.tests.test_collect_types.FooNamedTuple) -> EOFError'])
         self.assert_type_comments('OldStyleClass.foo', ['(int) -> int'])
 
         # Need __qualname__ to get this right
         if sys.version_info >= (3, 3):
             self.assert_type_comments(
                 'discard',
-                ['(pyannotate_runtime.tests.test_collect_types:FooObject.FooNested) -> None'])
+                ['(pyannotate_runtime.tests.test_collect_types.FooObject.FooNested) -> None'])
 
         # TODO: that could be better
         self.assert_type_comments('takes_different_lists', ['(List[Union[int, str]]) -> None'])
@@ -450,9 +450,9 @@ class TestCollectTypes(TestBaseClass):
                 func_sometimes_fail(0)
             except Exception:
                 pass
-        self.assert_type_comments('func_always_fail', ['(int) -> pyannotate_runtime.collect_types:NoReturnType',
-                                                       '(str) -> pyannotate_runtime.collect_types:NoReturnType'])
-        self.assert_type_comments('func_sometimes_fail', ['(int) -> pyannotate_runtime.collect_types:NoReturnType',
+        self.assert_type_comments('func_always_fail', ['(int) -> pyannotate_runtime.collect_types.NoReturnType',
+                                                       '(str) -> pyannotate_runtime.collect_types.NoReturnType'])
+        self.assert_type_comments('func_sometimes_fail', ['(int) -> pyannotate_runtime.collect_types.NoReturnType',
                                                           '(str) -> str'])
 
     def test_only_return(self):
@@ -523,8 +523,8 @@ class TestCollectTypes(TestBaseClass):
             identity_qualified(collect_types.TentativeType())
         self.assert_type_comments(
             'identity_qualified',
-            ['(pyannotate_runtime.collect_types:TentativeType) -> '
-             'pyannotate_runtime.collect_types:TentativeType'])
+            ['(pyannotate_runtime.collect_types.TentativeType) -> '
+             'pyannotate_runtime.collect_types.TentativeType'])
 
     def test_recursive_function(self):
         # type: () -> None
@@ -542,9 +542,9 @@ class TestCollectTypes(TestBaseClass):
         self.assert_type_comments(
             'recurse',
             ['(Tuple[]) -> float',
-             '(Tuple[bool]) -> pyannotate_runtime.collect_types:UnknownType',
-             '(Tuple[str, bool]) -> pyannotate_runtime.collect_types:UnknownType',
-             '(Tuple[int, str, bool]) -> pyannotate_runtime.collect_types:UnknownType'])
+             '(Tuple[bool]) -> pyannotate_runtime.collect_types.UnknownType',
+             '(Tuple[str, bool]) -> pyannotate_runtime.collect_types.UnknownType',
+             '(Tuple[int, str, bool]) -> pyannotate_runtime.collect_types.UnknownType'])
 
     def test_recursive_function_2(self):
         # type: () -> None
@@ -566,7 +566,7 @@ class TestCollectTypes(TestBaseClass):
             'recurse',
             ['(str) -> str',
              '(float) -> float',
-             '(int) -> pyannotate_runtime.collect_types:UnknownType'])
+             '(int) -> pyannotate_runtime.collect_types.UnknownType'])
 
     def test_ignoring_c_calls(self):
         # type: () -> None

--- a/pyannotate_runtime/tests/test_collect_types.py
+++ b/pyannotate_runtime/tests/test_collect_types.py
@@ -9,6 +9,7 @@ import contextlib
 import json
 import os
 import sched
+import sys
 import time
 import unittest
 from collections import namedtuple
@@ -51,6 +52,9 @@ def noop_dec(a):
     # type: (Any) -> Any
     return a
 
+def discard(a):
+    # type: (Any) -> None
+    pass
 
 @noop_dec
 class FoosParent(object):
@@ -58,7 +62,8 @@ class FoosParent(object):
 
 
 class FooObject(FoosParent):
-    pass
+    class FooNested(object):
+        pass
 
 
 class FooReturn(FoosParent):
@@ -314,6 +319,8 @@ class TestCollectTypes(TestBaseClass):
 
             OldStyleClass().foo(10)
 
+            discard(FooObject.FooNested())
+
         # TODO(svorobev): add checks for the rest of the functions
         # print_int,
         self.assert_type_comments(
@@ -323,6 +330,12 @@ class TestCollectTypes(TestBaseClass):
             'do_work_clsmthd',
             ['(int, pyannotate_runtime.tests.test_collect_types.FooNamedTuple) -> EOFError'])
         self.assert_type_comments('OldStyleClass.foo', ['(int) -> int'])
+
+        # Need __qualname__ to get this right
+        if sys.version_info >= (3, 3):
+            self.assert_type_comments(
+                'discard',
+                ['(pyannotate_runtime.tests.test_collect_types.FooObject.FooNested) -> None'])
 
         # TODO: that could be better
         self.assert_type_comments('takes_different_lists', ['(List[Union[int, str]]) -> None'])

--- a/pyannotate_runtime/tests/test_collect_types.py
+++ b/pyannotate_runtime/tests/test_collect_types.py
@@ -335,7 +335,7 @@ class TestCollectTypes(TestBaseClass):
         if sys.version_info >= (3, 3):
             self.assert_type_comments(
                 'discard',
-                ['(pyannotate_runtime.tests.test_collect_types.FooObject.FooNested) -> None'])
+                ['(pyannotate_runtime.tests.test_collect_types:FooObject.FooNested) -> None'])
 
         # TODO: that could be better
         self.assert_type_comments('takes_different_lists', ['(List[Union[int, str]]) -> None'])

--- a/pyannotate_runtime/tests/test_collect_types.py
+++ b/pyannotate_runtime/tests/test_collect_types.py
@@ -325,17 +325,17 @@ class TestCollectTypes(TestBaseClass):
         # print_int,
         self.assert_type_comments(
             'WorkerClass.__init__',
-            ['(int, pyannotate_runtime.tests.test_collect_types.FooObject) -> None'])
+            ['(int, pyannotate_runtime.tests.test_collect_types:FooObject) -> None'])
         self.assert_type_comments(
             'do_work_clsmthd',
-            ['(int, pyannotate_runtime.tests.test_collect_types.FooNamedTuple) -> EOFError'])
+            ['(int, pyannotate_runtime.tests.test_collect_types:FooNamedTuple) -> EOFError'])
         self.assert_type_comments('OldStyleClass.foo', ['(int) -> int'])
 
         # Need __qualname__ to get this right
         if sys.version_info >= (3, 3):
             self.assert_type_comments(
                 'discard',
-                ['(pyannotate_runtime.tests.test_collect_types.FooObject.FooNested) -> None'])
+                ['(pyannotate_runtime.tests.test_collect_types:FooObject.FooNested) -> None'])
 
         # TODO: that could be better
         self.assert_type_comments('takes_different_lists', ['(List[Union[int, str]]) -> None'])
@@ -450,9 +450,9 @@ class TestCollectTypes(TestBaseClass):
                 func_sometimes_fail(0)
             except Exception:
                 pass
-        self.assert_type_comments('func_always_fail', ['(int) -> pyannotate_runtime.collect_types.NoReturnType',
-                                                       '(str) -> pyannotate_runtime.collect_types.NoReturnType'])
-        self.assert_type_comments('func_sometimes_fail', ['(int) -> pyannotate_runtime.collect_types.NoReturnType',
+        self.assert_type_comments('func_always_fail', ['(int) -> pyannotate_runtime.collect_types:NoReturnType',
+                                                       '(str) -> pyannotate_runtime.collect_types:NoReturnType'])
+        self.assert_type_comments('func_sometimes_fail', ['(int) -> pyannotate_runtime.collect_types:NoReturnType',
                                                           '(str) -> str'])
 
     def test_only_return(self):
@@ -523,8 +523,8 @@ class TestCollectTypes(TestBaseClass):
             identity_qualified(collect_types.TentativeType())
         self.assert_type_comments(
             'identity_qualified',
-            ['(pyannotate_runtime.collect_types.TentativeType) -> '
-             'pyannotate_runtime.collect_types.TentativeType'])
+            ['(pyannotate_runtime.collect_types:TentativeType) -> '
+             'pyannotate_runtime.collect_types:TentativeType'])
 
     def test_recursive_function(self):
         # type: () -> None
@@ -542,9 +542,9 @@ class TestCollectTypes(TestBaseClass):
         self.assert_type_comments(
             'recurse',
             ['(Tuple[]) -> float',
-             '(Tuple[bool]) -> pyannotate_runtime.collect_types.UnknownType',
-             '(Tuple[str, bool]) -> pyannotate_runtime.collect_types.UnknownType',
-             '(Tuple[int, str, bool]) -> pyannotate_runtime.collect_types.UnknownType'])
+             '(Tuple[bool]) -> pyannotate_runtime.collect_types:UnknownType',
+             '(Tuple[str, bool]) -> pyannotate_runtime.collect_types:UnknownType',
+             '(Tuple[int, str, bool]) -> pyannotate_runtime.collect_types:UnknownType'])
 
     def test_recursive_function_2(self):
         # type: () -> None
@@ -566,7 +566,7 @@ class TestCollectTypes(TestBaseClass):
             'recurse',
             ['(str) -> str',
              '(float) -> float',
-             '(int) -> pyannotate_runtime.collect_types.UnknownType'])
+             '(int) -> pyannotate_runtime.collect_types:UnknownType'])
 
     def test_ignoring_c_calls(self):
         # type: () -> None

--- a/pyannotate_tools/annotations/parse.py
+++ b/pyannotate_tools/annotations/parse.py
@@ -188,7 +188,7 @@ def tokenize(s):
             tokens.append(Separator('->'))
             s = s[2:]
         else:
-            m = re.match(r'[-\w]+( *(\.|:) *[-/\w]*)*', s)
+            m = re.match(r'[-\w]+(\s*(\.|:)\s*[-/\w]*)*', s)
             if not m:
                 raise ParseError(original)
             fullname = m.group(0)

--- a/pyannotate_tools/annotations/parse.py
+++ b/pyannotate_tools/annotations/parse.py
@@ -188,7 +188,7 @@ def tokenize(s):
             tokens.append(Separator('->'))
             s = s[2:]
         else:
-            m = re.match(r'[-\w]+( *\. *[-/\w]*)*', s)
+            m = re.match(r'[-\w]+( *(\.|:) *[-/\w]*)*', s)
             if not m:
                 raise ParseError(original)
             fullname = m.group(0)

--- a/pyannotate_tools/fixes/fix_annotate_json.py
+++ b/pyannotate_tools/fixes/fix_annotate_json.py
@@ -274,12 +274,19 @@ class FixAnnotateJson(FixAnnotate):
         word = match.group()
         if word == '...':
             return word
-        if ':' not in word:
+        if '.' not in word and ':' not in word:
             # Assume it's either builtin or from `typing`
             if word in typing_all:
                 self.add_import('typing', word)
             return word
-        mod, name = word.split(':')
-        to_import = name.split('.', 1)[0]
+        # If there is a :, treat that as the separator between the
+        # module and the class.  Otherwise assume everything but the
+        # last element is the module.
+        if ':' in word:
+            mod, name = word.split(':')
+            to_import = name.split('.', 1)[0]
+        else:
+            mod, name = word.rsplit('.', 1)
+            to_import = name
         self.add_import(mod, to_import)
         return name

--- a/pyannotate_tools/fixes/tests/test_annotate_json_py2.py
+++ b/pyannotate_tools/fixes/tests/test_annotate_json_py2.py
@@ -667,7 +667,7 @@ class TestFixAnnotateJson(FixerTestCase):
               "path": "<string>",
               "line": 1,
               "signature": {
-                  "arg_types": ["foo.A.B"],
+                  "arg_types": ["foo:A.B"],
                   "return_type": "None"},
               }])
         a = """\

--- a/pyannotate_tools/fixes/tests/test_annotate_json_py2.py
+++ b/pyannotate_tools/fixes/tests/test_annotate_json_py2.py
@@ -92,7 +92,7 @@ class TestFixAnnotateJson(FixerTestCase):
               "line": 1,
               # Check with and without 'typing.' prefix
               "signature": {
-                  "arg_types": ["List[typing:AnyStr]", "Callable[[], int]"],
+                  "arg_types": ["List[typing.AnyStr]", "Callable[[], int]"],
                   "return_type": "object"},
               }])
         a = """\
@@ -115,8 +115,8 @@ class TestFixAnnotateJson(FixerTestCase):
               "path": "mod1.py",
               "line": 1,
               "signature": {
-                  "arg_types": ["mod1:MyClass", "mod2:OtherClass"],
-                  "return_type": "mod3:AnotherClass"},
+                  "arg_types": ["mod1.MyClass", "mod2.OtherClass"],
+                  "return_type": "mod3.AnotherClass"},
               }])
         a = """\
             def nop(foo, bar):
@@ -667,7 +667,7 @@ class TestFixAnnotateJson(FixerTestCase):
               "path": "<string>",
               "line": 1,
               "signature": {
-                  "arg_types": ["foo:A.B"],
+                  "arg_types": ["foo.A.B"],
                   "return_type": "None"},
               }])
         a = """\

--- a/pyannotate_tools/fixes/tests/test_annotate_json_py2.py
+++ b/pyannotate_tools/fixes/tests/test_annotate_json_py2.py
@@ -92,7 +92,7 @@ class TestFixAnnotateJson(FixerTestCase):
               "line": 1,
               # Check with and without 'typing.' prefix
               "signature": {
-                  "arg_types": ["List[typing.AnyStr]", "Callable[[], int]"],
+                  "arg_types": ["List[typing:AnyStr]", "Callable[[], int]"],
                   "return_type": "object"},
               }])
         a = """\
@@ -115,8 +115,8 @@ class TestFixAnnotateJson(FixerTestCase):
               "path": "mod1.py",
               "line": 1,
               "signature": {
-                  "arg_types": ["mod1.MyClass", "mod2.OtherClass"],
-                  "return_type": "mod3.AnotherClass"},
+                  "arg_types": ["mod1:MyClass", "mod2:OtherClass"],
+                  "return_type": "mod3:AnotherClass"},
               }])
         a = """\
             def nop(foo, bar):
@@ -667,7 +667,7 @@ class TestFixAnnotateJson(FixerTestCase):
               "path": "<string>",
               "line": 1,
               "signature": {
-                  "arg_types": ["foo.A.B"],
+                  "arg_types": ["foo:A.B"],
                   "return_type": "None"},
               }])
         a = """\

--- a/pyannotate_tools/fixes/tests/test_annotate_json_py2.py
+++ b/pyannotate_tools/fixes/tests/test_annotate_json_py2.py
@@ -660,3 +660,24 @@ class TestFixAnnotateJson(FixerTestCase):
                 return 0
             """
         self.check(a, b)
+
+    def test_nested(self):
+        self.setTestData(
+            [{"func_name": "nop",
+              "path": "<string>",
+              "line": 1,
+              "signature": {
+                  "arg_types": ["foo.A.B"],
+                  "return_type": "None"},
+              }])
+        a = """\
+            def nop(a):
+                pass
+            """
+        b = """\
+            from foo import A
+            def nop(a):
+                # type: (A.B) -> None
+                pass
+            """
+        self.check(a, b)

--- a/pyannotate_tools/fixes/tests/test_annotate_json_py3.py
+++ b/pyannotate_tools/fixes/tests/test_annotate_json_py3.py
@@ -90,7 +90,7 @@ class TestFixAnnotateJson(FixerTestCase):
               "line": 1,
               # Check with and without 'typing.' prefix
               "signature": {
-                  "arg_types": ["List[typing.AnyStr]", "Callable[[], int]"],
+                  "arg_types": ["List[typing:AnyStr]", "Callable[[], int]"],
                   "return_type": "object"},
               }])
         a = """\
@@ -112,8 +112,8 @@ class TestFixAnnotateJson(FixerTestCase):
               "path": "mod1.py",
               "line": 1,
               "signature": {
-                  "arg_types": ["mod1.MyClass", "mod2.OtherClass"],
-                  "return_type": "mod3.AnotherClass"},
+                  "arg_types": ["mod1:MyClass", "mod2:OtherClass"],
+                  "return_type": "mod3:AnotherClass"},
               }])
         a = """\
             def nop(foo, bar):

--- a/pyannotate_tools/fixes/tests/test_annotate_json_py3.py
+++ b/pyannotate_tools/fixes/tests/test_annotate_json_py3.py
@@ -90,7 +90,7 @@ class TestFixAnnotateJson(FixerTestCase):
               "line": 1,
               # Check with and without 'typing.' prefix
               "signature": {
-                  "arg_types": ["List[typing:AnyStr]", "Callable[[], int]"],
+                  "arg_types": ["List[typing.AnyStr]", "Callable[[], int]"],
                   "return_type": "object"},
               }])
         a = """\
@@ -112,8 +112,8 @@ class TestFixAnnotateJson(FixerTestCase):
               "path": "mod1.py",
               "line": 1,
               "signature": {
-                  "arg_types": ["mod1:MyClass", "mod2:OtherClass"],
-                  "return_type": "mod3:AnotherClass"},
+                  "arg_types": ["mod1.MyClass", "mod2.OtherClass"],
+                  "return_type": "mod3.AnotherClass"},
               }])
         a = """\
             def nop(foo, bar):


### PR DESCRIPTION
Without understanding the module hierarchy, we can't distinguish
between a module and a class in a dotted name like `foo.bar.A.B`, and
will insert code like `from foo.bar.A import B`, even though `A` is a
class.

Work around this with a cruddy heuristic that names beginning with a
capital letter are classes and not modules.

Another approach would be to introduce alternate punctuation like ! or
: to separate the module and class part of a name. This would have the
disadvantage of being pretty nonstandard but also not being an awful
hack.

The "nonstandard" argument seemed compelling when I first went
to implement this so I did the capital letter heuristic. But now it feels
pretty weak to me and I'd lean towards switching to it, but I figured I'd
get feedback first.