### PR TITLE
Update the current module when a new file is parsed

### DIFF
--- a/pyannotate_tools/fixes/fix_annotate_json.py
+++ b/pyannotate_tools/fixes/fix_annotate_json.py
@@ -169,6 +169,10 @@ class FixAnnotateJson(FixAnnotate):
                 touch_import(mod, name, node)
         self.needed_imports = None
 
+    def set_filename(self, filename):
+        super(FixAnnotateJson, self).set_filename(filename)
+        self._current_module = crawl_up(filename)[1]
+
     def current_module(self):
         return self._current_module
 
@@ -208,7 +212,7 @@ class FixAnnotateJson(FixAnnotate):
     @classmethod
     def init_stub_json_from_data(cls, data, filename):
         cls.stub_json = data
-        cls.top_dir, cls._current_module = crawl_up(os.path.abspath(filename))
+        cls.top_dir = crawl_up(os.path.abspath(filename))[0]
 
     def init_stub_json(self):
         with open(self.__class__.stub_json_file) as f:

--- a/pyannotate_tools/fixes/tests/test_annotate_json_py3.py
+++ b/pyannotate_tools/fixes/tests/test_annotate_json_py3.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 import unittest
 import sys
+from mock import patch
 
 from lib2to3.tests.test_fixers import FixerTestCase
 
@@ -632,3 +633,13 @@ class TestFixAnnotateJson(FixerTestCase):
                         return 42
             """
         self.check(a, b)
+
+    @patch('pyannotate_tools.fixes.fix_annotate_json.FixAnnotateJson.set_filename')
+    def test_set_filename(self, mocked_set_filename):
+        self.filename = "/path/to/fileA.py"
+        self.unchanged("")
+        mocked_set_filename.assert_called_with("/path/to/fileA.py")
+
+        self.filename = "/path/to/fileB.py"
+        self.unchanged("")
+        mocked_set_filename.assert_called_with("/path/to/fileB.py")


### PR DESCRIPTION
`FixAnnotateJson.current_module` is currently a constant value set in `__main__`, but this causes bugs when pyannotate is run on a package directory, where the current module should be updated for each file that is parsed.

To fix this, I implemented `set_filename`, which is inherited from `BaseFix`, to update the current module each time the file changes.

To test, I removed the annotation from `parse_type_comment` and created a `type_info.json` file to provide the type data:

```json
[
  {
    "func_name": "parse_type_comment", "line": 213, 
    "path": "/Users/chad/dev/pyannotate/pyannotate_tools/annotations/parse.py", 
    "samples": 0, 
    "signature": {
      "arg_types": ["str"], 
      "return_type": "Tuple[pyannotate_tools.annotations.parse:List[pyannotate_tools.annotations.parse.Argument], pyannotate_tools.annotations.parse.AbstractType]"
    }
  }
]
```

I saw two types of bugs with the current implementation.  

1) imports statements were added that imported types from the current module:

```
pyannotate --uses-signature pyannotate_tools pyannotate_runtime
Refactored pyannotate_tools/annotations/parse.py
--- pyannotate_tools/annotations/parse.py	(original)
+++ pyannotate_tools/annotations/parse.py	(refactored)
@@ -10,6 +10,9 @@
 import sys
 
 from typing import Any, List, Mapping, Set, Tuple
+from pyannotate_tools.annotations.parse import AbstractType
+from pyannotate_tools.annotations.parse import Argument
+from pyannotate_tools.annotations.parse import List
 try:
     from typing import Text
 except ImportError:
@@ -211,6 +214,7 @@
 
 
 def parse_type_comment(comment):
+    # type: (str) -> Tuple[List[Argument], AbstractType]
     """Parse a type comment of form '(arg1, ..., argN) -> ret'."""
     return Parser(comment).parse()
```

2) If I passed two packages on the command line the second would be completely ignored.

```
pyannotate --uses-signature pyannotate_runtime pyannotate_tools
No files need to be modified.
```
