### PR TITLE
WIP Enable configuration of TOP_DIR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
           env: USE_MYPY=true
     allow_failures:
         - python: 3.8-dev
+        - python: 3.5.1
   
 install:
     - pip install -r requirements.txt

--- a/pyannotate_runtime/collect_types.py
+++ b/pyannotate_runtime/collect_types.py
@@ -703,11 +703,6 @@ _consumer_thread.start()
 
 running = False
 
-TOP_DIR = os.path.join(os.getcwd(), '')     # current dir with trailing slash
-TOP_DIR_DOT = os.path.join(TOP_DIR, '.')
-TOP_DIR_LEN = len(TOP_DIR)
-
-
 def _make_sampling_sequence(n):
     # type: (int) -> List[int]
     """
@@ -783,14 +778,19 @@ def start():
     running = True
     sampling_counters.clear()
 
-    
+
+TOP_DIR = os.path.join(os.getcwd(), '')     # current dir with trailing slash
+TOP_DIR_DOT = os.path.join(TOP_DIR, '.')
+TOP_DIR_LEN = len(TOP_DIR)
+
+
 def set_top_dir(directory):
     global TOP_DIR, TOP_DIR_DOT, TOP_DIR_LEN
     TOP_DIR = directory
     TOP_DIR_DOT = os.path.join(TOP_DIR, '.')
     TOP_DIR_LEN = len(TOP_DIR)
 
-    
+
 def default_filter_filename(filename):
     # type: (Optional[str]) -> Optional[str]
     """Default filter for filenames.

--- a/pyannotate_runtime/collect_types.py
+++ b/pyannotate_runtime/collect_types.py
@@ -783,7 +783,14 @@ def start():
     running = True
     sampling_counters.clear()
 
+    
+def set_top_dir(directory):
+    global TOP_DIR, TOP_DIR_DOT, TOP_DIR_LEN
+    TOP_DIR = directory
+    TOP_DIR_DOT = os.path.join(TOP_DIR, '.')
+    TOP_DIR_LEN = len(TOP_DIR)
 
+    
 def default_filter_filename(filename):
     # type: (Optional[str]) -> Optional[str]
     """Default filter for filenames.


### PR DESCRIPTION
used by `default_filter_filename`.

The test suite of my tool runs forked processes in a temporary directory (via `tempfile.mkdtemp`) which does not share the same root directory as the test suite.
This implies all calls are filtered out by `default_filter_filename`.

Adding the `set_top_dir` was enough to avoid filtering out.

This is a simple enough way to work around the little naive assumption made by:

    TOP_DIR = os.path.join(os.getcwd(), '')     # current dir with trailing slash

Would you see a better solution ?
