### PR TITLE
Problem: TOP_DIR_x are global

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
           env: USE_MYPY=true
     allow_failures:
         - python: 3.8-dev
+        - python: 3.5.1
   
 install:
     - pip install -r requirements.txt

--- a/pyannotate_runtime/collect_types.py
+++ b/pyannotate_runtime/collect_types.py
@@ -703,11 +703,6 @@ _consumer_thread.start()
 
 running = False
 
-TOP_DIR = os.path.join(os.getcwd(), '')     # current dir with trailing slash
-TOP_DIR_DOT = os.path.join(TOP_DIR, '.')
-TOP_DIR_LEN = len(TOP_DIR)
-
-
 def _make_sampling_sequence(n):
     # type: (int) -> List[int]
     """
@@ -784,8 +779,8 @@ def start():
     sampling_counters.clear()
 
 
-def default_filter_filename(filename):
-    # type: (Optional[str]) -> Optional[str]
+def _default_filter_filename(top_dir, filename):
+    # type: (str, Optional[str]) -> Optional[str]
     """Default filter for filenames.
 
     Returns either a normalized filename or None.
@@ -793,19 +788,28 @@ def default_filter_filename(filename):
     """
     if filename is None:
         return None
-    elif filename.startswith(TOP_DIR):
-        if filename.startswith(TOP_DIR_DOT):
+    elif filename.startswith(top_dir):
+        top_dir_dot = os.path.join(top_dir, '.')
+        if filename.startswith(top_dir_dot):
             # Skip subdirectories starting with dot (e.g. .vagrant).
             return None
         else:
             # Strip current directory and following slashes.
-            return filename[TOP_DIR_LEN:].lstrip(os.sep)
+            return filename[len(top_dir):].lstrip(os.sep)
     elif filename.startswith(os.sep):
         # Skip absolute paths not under current directory.
         return None
     else:
         return filename
 
+
+def configure_default_filter_top_dir(directory):
+    from functools import partial
+    return partial(_default_filter_filename, directory)
+
+
+default_filter_filename = configure_default_filter_top_dir(
+        os.path.join(os.getcwd()))
 
 _filter_filename = default_filter_filename  # type: Callable[[Optional[str]], Optional[str]]
 

--- a/pyannotate_runtime/tests/test_collect_types.py
+++ b/pyannotate_runtime/tests/test_collect_types.py
@@ -229,7 +229,7 @@ class TestBaseClass(unittest.TestCase):
                 print('    ' + comment)
             assert set(item['type_comments']) == set(comments)
         assert len(item['type_comments']) == len(comments)
-        assert os.path.join(collect_types.TOP_DIR, item['path']) == __file__
+        assert os.path.join(os.getcwd(), item['path']) == __file__
 
 
 class TestCollectTypes(TestBaseClass):


### PR DESCRIPTION
In the context of @gvanrossum comment on #111, I looked a bit closer to the globals `TOP_DIR_x`.

IMHO, it is not needed to keep them global.

This PR would replace #111. (Nevertheless, I fixed #111 in order to let you decide which one you prefer.) 

The code in this PR enables customizing the `default_filter_filename` `top_dir`with the following code:

    top_filter = collect_types.configure_default_filter_top_dir(top_dir)
    collect_types.init_types_collection(filter_filename=top_filter)