### PR TITLE
Replace mypy_extensions with typing_extensions

### DIFF
--- a/pyannotate_runtime/collect_types.py
+++ b/pyannotate_runtime/collect_types.py
@@ -33,7 +33,6 @@ import threading
 from inspect import ArgInfo
 from threading import Thread
 
-from mypy_extensions import TypedDict
 from six import iteritems
 from six.moves import range
 from six.moves.queue import Queue  # type: ignore  # No library stub yet
@@ -52,6 +51,7 @@ from typing import (
     TypeVar,
     Union,
 )
+from typing_extensions import TypedDict
 from contextlib import contextmanager
 
 MYPY=False

--- a/pyannotate_tools/annotations/main.py
+++ b/pyannotate_tools/annotations/main.py
@@ -3,7 +3,7 @@
 import json
 
 from typing import List
-from mypy_extensions import TypedDict
+from typing_extensions import TypedDict
 
 from pyannotate_tools.annotations.types import ARG_STAR, ARG_STARSTAR
 from pyannotate_tools.annotations.infer import infer_annotation

--- a/pyannotate_tools/annotations/parse.py
+++ b/pyannotate_tools/annotations/parse.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     # In Python 3.5.1 stdlib, typing.py does not define Text
     Text = str  # type: ignore
-from mypy_extensions import NoReturn, TypedDict
+from typing_extensions import NoReturn, TypedDict
 
 from pyannotate_tools.annotations.types import (
     AbstractType,
@@ -42,7 +42,7 @@ TYPE_FIXUPS = {
     'dictionary-valueiterator': 'Iterator',
     'dictionary-itemiterator': 'Iterator',
     'pyannotate_runtime.collect_types.UnknownType': 'Any',
-    'pyannotate_runtime.collect_types.NoReturnType': 'mypy_extensions.NoReturn',
+    'pyannotate_runtime.collect_types.NoReturnType': 'typing_extensions.NoReturn',
     'function': 'Callable',
     'functools.partial': 'Callable',
     'long': 'int',
@@ -284,7 +284,7 @@ class Parser(object):
             self.fail()
         if t.text == 'Any':
             return AnyType()
-        elif t.text == 'mypy_extensions.NoReturn':
+        elif t.text == 'typing_extensions.NoReturn':
             return NoReturnType()
         elif t.text == 'Tuple':
             self.expect('[')

--- a/pyannotate_tools/annotations/types.py
+++ b/pyannotate_tools/annotations/types.py
@@ -53,11 +53,11 @@ class AnyType(AbstractType):
 
 
 class NoReturnType(AbstractType):
-    """The type mypy_extensions.NoReturn"""
+    """The type typing_extensions.NoReturn"""
 
     def __repr__(self):
         # type: () -> str
-        return 'mypy_extensions.NoReturn'
+        return 'typing_extensions.NoReturn'
 
     def __eq__(self, other):
         # type: (object) -> bool

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-mypy_extensions>=0.3.0
 pytest>=3.3.0
 setuptools>=28.8.0
 six>=1.11.0
-typing>=3.6.2; python_version < '3.5'
+typing>=3.5.3; python_version < '3.5'
+typing_extensions>=3.7.4

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(name='pyannotate',
           'Topic :: Software Development',
           ],
       install_requires = ['six',
-                          'mypy_extensions',
-                          'typing >= 3.5.3; python_version < "3.5"'
+                          'typing >= 3.5.3; python_version < "3.5"',
+                          'typing_extensions >= 3.7.4'
                           ],
       )


### PR DESCRIPTION
This makes generated types automatically compatible with Python 3.4. Also, mypy recommends typing_extensions over mypy_extensions when possible.