### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pyannotate_tools/annotations/infer.py
+++ b/pyannotate_tools/annotations/infer.py
@@ -100,7 +100,7 @@ def simplify_types(types):
     items = [simplify_recursive(item) for item in items]
     items = merge_items(items)
     items = dedupe_types(items)
-    # We have to remove reundant items after everything has been simplified and
+    # We have to remove redundant items after everything has been simplified and
     # merged as this simplification may be what makes items redundant.
     items = remove_redundant_items(items)
     if len(items) > 3:

--- a/pyannotate_tools/fixes/fix_annotate.py
+++ b/pyannotate_tools/fixes/fix_annotate.py
@@ -5,7 +5,7 @@ This transforms e.g.
   def foo(self, bar, baz=12):
       return bar + baz
 
-into a type annoted version:
+into a type annotated version:
 
 	  def foo(self, bar, baz=12):
 	      # type: (Any, int) -> Any            # noqa: F821


### PR DESCRIPTION
There are small typos in:
- pyannotate_tools/annotations/infer.py
- pyannotate_tools/fixes/fix_annotate.py

Fixes:
- Should read `redundant` rather than `reundant`.
- Should read `annotated` rather than `annoted`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md